### PR TITLE
Added version numbering information

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,18 @@ range of open source licenses. Permission for this release has been
 obtained from the SOFA board, and is avilable in the ``LICENSE`` file included
 in this source distribution.
 
+Differences from SOFA
+---------------------
+
+This version of ERFA (x.x) is based on SOFA version "20120301_a", with the 
+differences outlined below.
+
+ERFA Branding
+^^^^^^^^^^^^^
+
+All references to "SOFA" in the source code have been changed to ERFA, and
+instead of ``iau``, function prefixes are all 
+
 
 Travis Build Status
 -------------------


### PR DESCRIPTION
This adds a section to `README.rst` that both specifies the SOFA version this is derived from and outlines the differences.

Note that this conflicts with #7 in that it also adds the "differences from SOFA" section.  Whichever gets merged second will need to be rebased/merged to include this information, but that's straightforward enough.

Also note that once #6 is resolved, the `x.x` of the current version should be updated appropriately.
