### PR TITLE
Updated libtool version-info to get correct SONAME versions

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,7 +37,7 @@ include_HEADERS = erfa.h erfam.h
 PKG_MAJ = `echo $(PACKAGE_VERSION) | cut -d . -f 1`
 PKG_MIN = `echo $(PACKAGE_VERSION) | cut -d . -f 2`
 PKG_BUG = `echo $(PACKAGE_VERSION) | cut -d . -f 3`
-VI_CURR =  $(shell echo $(PKG_MAJ)+$(PKG_MIN) | bc)
+VI_CURR =  $(shell expr $(PKG_MAJ) + $(PKG_MIN))
 VI_REV = $(PKG_BUG)
 VI_AGE = $(PKG_MIN)
 


### PR DESCRIPTION
As pointed out by @olebole, the current release does not set the SONAME correctly, because the libtool `-version-info` option was not set.  This PR adds some macros to the makefile that automatically derives the libtool version from the ERFA package version.  That seems better than remembering to manually update at every release (especially given libtool's weird versioning scheme).
