### PR TITLE
Update to SOFA 2015-02-09

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ in this source distribution.
 Differences from SOFA
 ---------------------
 
-This version of ERFA (v1.1.1) is based on SOFA version "20131202_c", with the
+This version of ERFA (v1.2.1) is based on SOFA version "20150209", with the
 differences outlined below.
 
 ERFA branding

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Bugfixes
 ERFA includes smaller changes that may or may not eventually make it into SOFA,
 addressing localized bugs or similar smaller issues:
 
-* `Issue #14 <https://github.com/liberfa/erfa/pull/14>`_: Check for possible buffer underrun in ``dat.c``
+* None
 
 Building and installing ERFA
 ----------------------------

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,9 @@ Bugfixes
 ERFA includes smaller changes that may or may not eventually make it into SOFA,
 addressing localized bugs or similar smaller issues:
 
-* None
+* Fixes a possible compiler warning in eraDat. This fix was in SOFA
+  issue 2013-02-02d but inadvertently dropped from SOFA issue 2015-02-09.
+  ERFA retains the fix, which will be included in a future SOFA release.
 
 Building and installing ERFA
 ----------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 
 AC_PREREQ([2.68])
 ## Follow the instructions in RELEASE.rst to change package version
-AC_INIT([erfa],[1.1.1])
+AC_INIT([erfa],[1.2.1])
 AC_CONFIG_SRCDIR([src/erfa.h])
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([m4])
@@ -17,7 +17,7 @@ ERFA_NUMVER
 ## A library supports interfaces from current downto current - age
 ## Revision is the version of the current interface
 ## Follow the instructions in RELEASE.rst to change the version info
-ERFA_LIB_VERSION_INFO(2, 1, 1)
+ERFA_LIB_VERSION_INFO(2, 2, 0)
 
 # Checks for libraries.
 AC_SEARCH_LIBS([sin], [m], , AC_MSG_ERROR([cannot find math functions]))

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 
 AC_PREREQ([2.68])
 ## Follow the instructions in RELEASE.rst to change package version
-AC_INIT([erfa],[1.2.1])
+AC_INIT([erfa],[1.1.1])
 AC_CONFIG_SRCDIR([src/erfa.h])
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([m4])
@@ -17,7 +17,7 @@ ERFA_NUMVER
 ## A library supports interfaces from current downto current - age
 ## Revision is the version of the current interface
 ## Follow the instructions in RELEASE.rst to change the version info
-ERFA_LIB_VERSION_INFO(2, 2, 0)
+ERFA_LIB_VERSION_INFO(2, 1, 1)
 
 # Checks for libraries.
 AC_SEARCH_LIBS([sin], [m], , AC_MSG_ERROR([cannot find math functions]))

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,9 +10,9 @@ dtf2d.c ee00a.c ee00b.c ee00.c ee06a.c eect00.c eform.c eo06a.c \
 eors.c epb2jd.c epb.c epj2jd.c epj.c epv00.c eqeq94.c era00.c \
 fad03.c fae03.c faf03.c faju03.c fal03.c falp03.c fama03.c \
 fame03.c fane03.c faom03.c fapa03.c fasa03.c faur03.c fave03.c \
-fk52h.c fk5hip.c fk5hz.c fw2m.c fw2xy.c gc2gd.c gc2gde.c gd2gc.c \
+fk52h.c fk5hip.c fk5hz.c fw2m.c fw2xy.c g2icrs.c gc2gd.c gc2gde.c gd2gc.c \
 gd2gce.c gmst00.c gmst06.c gmst82.c gst00a.c gst00b.c gst06a.c \
-gst06.c gst94.c h2fk5.c hfk5z.c ir.c jd2cal.c jdcalf.c ld.c \
+gst06.c gst94.c h2fk5.c hfk5z.c icrs2g.c ir.c jd2cal.c jdcalf.c ld.c \
 ldn.c ldsun.c num00a.c num00b.c num06a.c numat.c nut00a.c nut00b.c \
 nut06a.c nut80.c nutm80.c obl06.c obl80.c p06e.c p2pv.c p2s.c pap.c \
 pas.c pb06.c pdp.c pfw06.c plan94.c pmat00.c pmat06.c pmat76.c \

--- a/src/a2af.c
+++ b/src/a2af.c
@@ -51,13 +51,12 @@ void eraA2af(int ndp, double angle, char *sign, int idmsf[4])
 **     case where angle is very nearly 2pi and rounds up to 360 degrees,
 **     by testing for idmsf[0]=360 and setting idmsf[0-3] to zero.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
 /* Hours to degrees * radians to turns */
    const double F = 15.0 / ERFA_D2PI;
-
 
 /* Scale then use days to h,m,s function. */
    eraD2tf(ndp, angle*F, sign, idmsf);
@@ -68,7 +67,7 @@ void eraA2af(int ndp, double angle, char *sign, int idmsf[4])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/a2tf.c
+++ b/src/a2tf.c
@@ -51,7 +51,7 @@ void eraA2tf(int ndp, double angle, char *sign, int ihmsf[4])
 **     case where angle is very nearly 2pi and rounds up to 24 hours,
 **     by testing for ihmsf[0]=24 and setting ihmsf[0-3] to zero.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -64,7 +64,7 @@ void eraA2tf(int ndp, double angle, char *sign, int ihmsf[4])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/ab.c
+++ b/src/ab.c
@@ -48,13 +48,12 @@ void eraAb(double pnat[3], double v[3], double s, double bm1,
 **  Called:
 **     eraPdp       scalar product of two p-vectors
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int i;
    double pdv, w1, w2, r2, w, p[3], r;
-
 
    pdv = eraPdp(pnat, v);
    w1 = 1.0 + pdv/(1.0 + bm1);
@@ -76,7 +75,7 @@ void eraAb(double pnat[3], double v[3], double s, double bm1,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/af2a.c
+++ b/src/af2a.c
@@ -34,7 +34,7 @@ int eraAf2a(char s, int ideg, int iamin, double asec, double *rad)
 **  3)  If there are multiple errors, the status value reflects only the
 **      first, the smallest taking precedence.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -55,7 +55,7 @@ int eraAf2a(char s, int ideg, int iamin, double asec, double *rad)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/anp.c
+++ b/src/anp.c
@@ -14,12 +14,11 @@ double eraAnp(double a)
 **  Returned (function value):
 **              double     angle in range 0-2pi
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double w;
-
 
    w = fmod(a, ERFA_D2PI);
    if (w < 0) w += ERFA_D2PI;
@@ -30,7 +29,7 @@ double eraAnp(double a)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/anpm.c
+++ b/src/anpm.c
@@ -14,12 +14,11 @@ double eraAnpm(double a)
 **  Returned (function value):
 **              double     angle in range +/-pi
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double w;
-
 
    w = fmod(a, ERFA_D2PI);
    if (fabs(w) >= ERFA_DPI) w -= ERFA_DSIGN(ERFA_D2PI, a);
@@ -30,7 +29,7 @@ double eraAnpm(double a)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/apcg.c
+++ b/src/apcg.c
@@ -102,14 +102,13 @@ void eraApcg(double date1, double date2,
 **  Called:
 **     eraApcs      astrometry parameters, ICRS-GCRS, space observer
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
 /* Geocentric observer */
    double pv[2][3] = { { 0.0, 0.0, 0.0 },
                        { 0.0, 0.0, 0.0 } };
-
 
 /* Compute the star-independent astrometry parameters. */
    eraApcs(date1, date2, pv, ebpv, ehp, astrom);
@@ -120,7 +119,7 @@ void eraApcg(double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/apcg13.c
+++ b/src/apcg13.c
@@ -104,12 +104,11 @@ void eraApcg13(double date1, double date2, eraASTROM *astrom)
 **     eraEpv00     Earth position and velocity
 **     eraApcg      astrometry parameters, ICRS-GCRS, geocenter
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double ehpv[2][3], ebpv[2][3];
-
 
 /* Earth barycentric & heliocentric position/velocity (au, au/d). */
    (void) eraEpv00(date1, date2, ehpv, ebpv);
@@ -123,7 +122,7 @@ void eraApcg13(double date1, double date2, eraASTROM *astrom)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/apci.c
+++ b/src/apci.c
@@ -112,7 +112,7 @@ void eraApci(double date1, double date2,
 **     eraApcg      astrometry parameters, ICRS-GCRS, geocenter
 **     eraC2ixys    celestial-to-intermediate matrix, given X,Y and s
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -129,7 +129,7 @@ void eraApci(double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/apci13.c
+++ b/src/apci13.c
@@ -110,12 +110,11 @@ void eraApci13(double date1, double date2,
 **     eraApci      astrometry parameters, ICRS-CIRS
 **     eraEors      equation of the origins, given NPB matrix and s
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double ehpv[2][3], ebpv[2][3], r[3][3], x, y, s;
-
 
 /* Earth barycentric & heliocentric position/velocity (au, au/d). */
    (void) eraEpv00(date1, date2, ehpv, ebpv);
@@ -141,7 +140,7 @@ void eraApci13(double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/apco.c
+++ b/src/apco.c
@@ -152,12 +152,11 @@ void eraApco(double date1, double date2,
 **     eraApcs      astrometry parameters, ICRS-GCRS, space observer
 **     eraCr        copy r-matrix
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double sl, cl, r[3][3], pvc[2][3], pv[2][3];
-
 
 /* Longitude with adjustment for TIO locator s'. */
    astrom->along = elong + sp;
@@ -203,7 +202,7 @@ void eraApco(double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/apco13.c
+++ b/src/apco13.c
@@ -173,14 +173,13 @@ int eraApco13(double utc1, double utc2, double dut1,
 **     eraApco      astrometry parameters, ICRS-observed
 **     eraEors      equation of the origins, given NPB matrix and s
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int j;
    double tai1, tai2, tt1, tt2, ut11, ut12, ehpv[2][3], ebpv[2][3],
           r[3][3], x, y, s, theta, sp, refa, refb;
-
 
 /* UTC to other time scales. */
    j = eraUtctai(utc1, utc2, &tai1, &tai2);
@@ -226,7 +225,7 @@ int eraApco13(double utc1, double utc2, double dut1,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/apcs.c
+++ b/src/apcs.c
@@ -122,7 +122,7 @@ void eraApcs(double date1, double date2, double pv[2][3],
 **     eraPn        decompose p-vector into modulus and direction
 **     eraIr        initialize r-matrix to identity
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -134,7 +134,6 @@ void eraApcs(double date1, double date2, double pv[2][3],
 
    int i;
    double dp, dv, pb[3], vb[3], ph[3], v2, w;
-
 
 /* Time since reference epoch, years (for proper motion calculation). */
    astrom->pmt = ( (date1 - ERFA_DJ00) + date2 ) / ERFA_DJY;
@@ -172,7 +171,7 @@ void eraApcs(double date1, double date2, double pv[2][3],
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/apcs13.c
+++ b/src/apcs13.c
@@ -111,12 +111,11 @@ void eraApcs13(double date1, double date2, double pv[2][3],
 **     eraEpv00     Earth position and velocity
 **     eraApcs      astrometry parameters, ICRS-GCRS, space observer
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double ehpv[2][3], ebpv[2][3];
-
 
 /* Earth barycentric & heliocentric position/velocity (au, au/d). */
    (void) eraEpv00(date1, date2, ehpv, ebpv);
@@ -130,7 +129,7 @@ void eraApcs13(double date1, double date2, double pv[2][3],
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/aper.c
+++ b/src/aper.c
@@ -89,7 +89,7 @@ void eraAper(double theta, eraASTROM *astrom)
 **     aberration and parallax (unless subsumed into the ICRS <-> GCRS
 **     transformation), and atmospheric refraction.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -101,7 +101,7 @@ void eraAper(double theta, eraASTROM *astrom)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/aper13.c
+++ b/src/aper13.c
@@ -108,7 +108,7 @@ void eraAper13(double ut11, double ut12, eraASTROM *astrom)
 **     eraAper      astrometry parameters: update ERA
 **     eraEra00     Earth rotation angle, IAU 2000
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -120,7 +120,7 @@ void eraAper13(double ut11, double ut12, eraASTROM *astrom)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/apio.c
+++ b/src/apio.c
@@ -113,12 +113,11 @@ void eraApio(double sp, double theta,
 **     eraPvtob     position/velocity of terrestrial station
 **     eraAper      astrometry parameters: update ERA
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double sl, cl, pv[2][3];
-
 
 /* Longitude with adjustment for TIO locator s'. */
    astrom->along = elong + sp;
@@ -152,7 +151,7 @@ void eraApio(double sp, double theta,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/apio13.c
+++ b/src/apio13.c
@@ -162,13 +162,12 @@ int eraApio13(double utc1, double utc2, double dut1,
 **     eraRefco     refraction constants for given ambient conditions
 **     eraApio      astrometry parameters, CIRS-observed
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int j;
    double tai1, tai2, tt1, tt2, ut11, ut12, sp, theta, refa, refb;
-
 
 /* UTC to other time scales. */
    j = eraUtctai(utc1, utc2, &tai1, &tai2);
@@ -198,7 +197,7 @@ int eraApio13(double utc1, double utc2, double dut1,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/atci13.c
+++ b/src/atci13.c
@@ -78,13 +78,12 @@ void eraAtci13(double rc, double dc,
 **     eraApci13    astrometry parameters, ICRS-CIRS, 2013
 **     eraAtciq     quick ICRS to CIRS
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
 /* Star-independent astrometry parameters */
    eraASTROM astrom;
-
 
 /* The transformation parameters. */
    eraApci13(date1, date2, &astrom, eo);
@@ -98,7 +97,7 @@ void eraAtci13(double rc, double dc,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/atciq.c
+++ b/src/atciq.c
@@ -64,12 +64,11 @@ void eraAtciq(double rc, double dc,
 **     eraC2s       p-vector to spherical
 **     eraAnp       normalize angle into range 0 to 2pi
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double pco[3], pnat[3], ppr[3], pi[3], w;
-
 
 /* Proper motion and parallax, giving BCRS coordinate direction. */
    eraPmpx(rc, dc, pr, pd, px, rv, astrom->pmt, astrom->eb, pco);
@@ -93,7 +92,7 @@ void eraAtciq(double rc, double dc,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/atciqn.c
+++ b/src/atciqn.c
@@ -17,7 +17,6 @@ void eraAtciqn(double rc, double dc, double pr, double pd,
 **  star-independent parameters can be obtained by calling one of the
 **  functions eraApci[13], eraApcg[13], eraApco[13] or eraApcs[13].
 **
-**
 **  If the only light-deflecting body to be taken into account is the
 **  Sun, the eraAtciq function can be used instead.  If in addition the
 **  parallax and proper motions are zero, the eraAtciqz function can be
@@ -101,12 +100,11 @@ void eraAtciqn(double rc, double dc, double pr, double pd,
 **     eraC2s       p-vector to spherical
 **     eraAnp       normalize angle into range 0 to 2pi
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double pco[3], pnat[3], ppr[3], pi[3], w;
-
 
 /* Proper motion and parallax, giving BCRS coordinate direction. */
    eraPmpx(rc, dc, pr, pd, px, rv, astrom->pmt, astrom->eb, pco);
@@ -130,7 +128,7 @@ void eraAtciqn(double rc, double dc, double pr, double pd,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/atciqz.c
+++ b/src/atciqz.c
@@ -63,12 +63,11 @@ void eraAtciqz(double rc, double dc, eraASTROM *astrom,
 **     eraC2s       p-vector to spherical
 **     eraAnp       normalize angle into range +/- pi
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double pco[3], pnat[3], ppr[3], pi[3], w;
-
 
 /* BCRS coordinate direction (unit vector). */
    eraS2c(rc, dc, pco);
@@ -92,7 +91,7 @@ void eraAtciqz(double rc, double dc, eraASTROM *astrom,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/atco13.c
+++ b/src/atco13.c
@@ -151,14 +151,13 @@ int eraAtco13(double rc, double dc,
 **     eraAtciq     quick ICRS to CIRS
 **     eraAtioq     quick ICRS to observed
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int j;
    eraASTROM astrom;
    double ri, di;
-
 
 /* Star-independent astrometry parameters. */
    j = eraApco13(utc1, utc2, dut1, elong, phi, hm, xp, yp,
@@ -182,7 +181,7 @@ int eraAtco13(double rc, double dc,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/atic13.c
+++ b/src/atic13.c
@@ -71,13 +71,12 @@ void eraAtic13(double ri, double di, double date1, double date2,
 **     eraApci13    astrometry parameters, ICRS-CIRS, 2013
 **     eraAticq     quick CIRS to ICRS astrometric
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
 /* Star-independent astrometry parameters */
    eraASTROM astrom;
-
 
 /* Star-independent astrometry parameters. */
    eraApci13(date1, date2, &astrom, eo);
@@ -91,7 +90,7 @@ void eraAtic13(double ri, double di, double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/aticq.c
+++ b/src/aticq.c
@@ -59,14 +59,13 @@ void eraAticq(double ri, double di, eraASTROM *astrom,
 **     eraC2s       p-vector to spherical
 **     eraAnp       normalize angle into range +/- pi
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int j, i;
    double pi[3], ppr[3], pnat[3], pco[3], w, d[3], before[3], r2, r,
           after[3];
-
 
 /* CIRS RA,Dec to Cartesian. */
    eraS2c(ri, di, pi);
@@ -138,7 +137,7 @@ void eraAticq(double ri, double di, eraASTROM *astrom,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/aticqn.c
+++ b/src/aticqn.c
@@ -97,14 +97,13 @@ void eraAticqn(double ri, double di, eraASTROM *astrom,
 **     eraC2s       p-vector to spherical
 **     eraAnp       normalize angle into range +/- pi
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int j, i;
    double pi[3], ppr[3], pnat[3], pco[3], w, d[3], before[3], r2, r,
           after[3];
-
 
 /* CIRS RA,Dec to Cartesian. */
    eraS2c(ri, di, pi);
@@ -176,7 +175,7 @@ void eraAticqn(double ri, double di, eraASTROM *astrom,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/atio13.c
+++ b/src/atio13.c
@@ -134,13 +134,12 @@ int eraAtio13(double ri, double di,
 **     eraApio13    astrometry parameters, CIRS-observed, 2013
 **     eraAtioq     quick ICRS to observed
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int j;
    eraASTROM astrom;
-
 
 /* Star-independent astrometry parameters for CIRS->observed. */
    j = eraApio13(utc1, utc2, dut1, elong, phi, hm, xp, yp,
@@ -161,7 +160,7 @@ int eraAtio13(double ri, double di,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/atioq.c
+++ b/src/atioq.c
@@ -95,7 +95,7 @@ void eraAtioq(double ri, double di, eraASTROM *astrom,
 **     eraC2s       p-vector to spherical
 **     eraAnp       normalize angle into range 0 to 2pi
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -183,7 +183,7 @@ void eraAtioq(double ri, double di, eraASTROM *astrom,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/atoc13.c
+++ b/src/atoc13.c
@@ -141,14 +141,13 @@ int eraAtoc13(const char *type, double ob1, double ob2,
 **     eraAtoiq     quick observed to CIRS
 **     eraAticq     quick CIRS to ICRS
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int j;
    eraASTROM astrom;
    double eo, ri, di;
-
 
 /* Star-independent astrometry parameters. */
    j = eraApco13(utc1, utc2, dut1, elong, phi, hm, xp, yp,
@@ -172,7 +171,7 @@ int eraAtoc13(const char *type, double ob1, double ob2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/atoi13.c
+++ b/src/atoi13.c
@@ -140,13 +140,12 @@ int eraAtoi13(const char *type, double ob1, double ob2,
 **     eraApio13    astrometry parameters, CIRS-observed, 2013
 **     eraAtoiq     quick observed to CIRS
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int j;
    eraASTROM astrom;
-
 
 /* Star-independent astrometry parameters for CIRS->observed. */
    j = eraApio13(utc1, utc2, dut1, elong, phi, hm, xp, yp,
@@ -167,7 +166,7 @@ int eraAtoi13(const char *type, double ob1, double ob2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/atoiq.c
+++ b/src/atoiq.c
@@ -88,7 +88,7 @@ void eraAtoiq(const char *type,
 **     eraC2s       p-vector to spherical
 **     eraAnp       normalize angle into range 0 to 2pi
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -97,7 +97,6 @@ void eraAtoiq(const char *type,
           xmhdo, ymhdo, zmhdo, az, sz, zdo, refa, refb, tz, dref,
           zdt, xaet, yaet, zaet, xmhda, ymhda, zmhda,
           f, xhd, yhd, zhd, xpl, ypl, w, hma;
-
 
 /* Coordinate type. */
    c = (int) type[0];
@@ -199,7 +198,7 @@ void eraAtoiq(const char *type,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/bi00.c
+++ b/src/bi00.c
@@ -41,7 +41,7 @@ void eraBi00(double *dpsibi, double *depsbi, double *dra)
 **     2002.  The MHB2000 code itself was obtained on 9th September 2002
 **     from ftp://maia.usno.navy.mil/conv2000/chapter5/IAU2000A.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -51,7 +51,6 @@ void eraBi00(double *dpsibi, double *depsbi, double *dra)
 
 /* The ICRS RA of the J2000.0 equinox (Chapront et al., 2002) */
    const double DRA0 = -0.0146 * ERFA_DAS2R;
-
 
 /* Return the results (which are fixed). */
    *dpsibi = DPBIAS;
@@ -64,7 +63,7 @@ void eraBi00(double *dpsibi, double *depsbi, double *dra)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/bp00.c
+++ b/src/bp00.c
@@ -70,7 +70,7 @@ void eraBp00(double date1, double date2,
 **     n.b. The celestial ephemeris origin (CEO) was renamed "celestial
 **          intermediate origin" (CIO) by IAU 2006 Resolution 2.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -79,7 +79,6 @@ void eraBp00(double date1, double date2,
 
    double t, dpsibi, depsbi, dra0, psia77, oma77, chia,
           dpsipr, depspr, psia, oma, rbw[3][3];
-
 
 /* Interval between fundamental epoch J2000.0 and current date (JC). */
    t = ((date1 - ERFA_DJ00) + date2) / ERFA_DJC;
@@ -120,7 +119,7 @@ void eraBp00(double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/bp06.c
+++ b/src/bp06.c
@@ -64,12 +64,11 @@ void eraBp06(double date1, double date2,
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double gamb, phib, psib, epsa, rbpw[3][3], rbt[3][3];
-
 
 /* B matrix. */
    eraPfw06(ERFA_DJM0, ERFA_DJM00, &gamb, &phib, &psib, &epsa);
@@ -91,7 +90,7 @@ void eraBp06(double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/bpn2xy.c
+++ b/src/bpn2xy.c
@@ -34,7 +34,7 @@ void eraBpn2xy(double rbpn[3][3], double *x, double *y)
 **     n.b. The celestial ephemeris origin (CEO) was renamed "celestial
 **          intermediate origin" (CIO) by IAU 2006 Resolution 2.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -48,7 +48,7 @@ void eraBpn2xy(double rbpn[3][3], double *x, double *y)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/c2i00a.c
+++ b/src/c2i00a.c
@@ -68,12 +68,11 @@ void eraC2i00a(double date1, double date2, double rc2i[3][3])
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double rbpn[3][3];
-
 
 /* Obtain the celestial-to-true matrix (IAU 2000A). */
    eraPnm00a(date1, date2, rbpn);
@@ -87,7 +86,7 @@ void eraC2i00a(double date1, double date2, double rc2i[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/c2i00b.c
+++ b/src/c2i00b.c
@@ -68,12 +68,11 @@ void eraC2i00b(double date1, double date2, double rc2i[3][3])
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double rbpn[3][3];
-
 
 /* Obtain the celestial-to-true matrix (IAU 2000B). */
    eraPnm00b(date1, date2, rbpn);
@@ -87,7 +86,7 @@ void eraC2i00b(double date1, double date2, double rc2i[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/c2i06a.c
+++ b/src/c2i06a.c
@@ -59,12 +59,11 @@ void eraC2i06a(double date1, double date2, double rc2i[3][3])
 **     McCarthy, D. D., Petit, G. (eds.), 2004, IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double rbpn[3][3], x, y, s;
-
 
 /* Obtain the celestial-to-true matrix (IAU 2006/2000A). */
    eraPnm06a(date1, date2, rbpn);
@@ -84,7 +83,7 @@ void eraC2i06a(double date1, double date2, double rc2i[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/c2ibpn.c
+++ b/src/c2ibpn.c
@@ -71,12 +71,11 @@ void eraC2ibpn(double date1, double date2, double rbpn[3][3],
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double x, y;
-
 
 /* Extract the X,Y coordinates. */
    eraBpn2xy(rbpn, &x, &y);
@@ -90,7 +89,7 @@ void eraC2ibpn(double date1, double date2, double rbpn[3][3],
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/c2ixy.c
+++ b/src/c2ixy.c
@@ -65,7 +65,7 @@ void eraC2ixy(double date1, double date2, double x, double y,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 
@@ -79,7 +79,7 @@ void eraC2ixy(double date1, double date2, double x, double y,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/c2ixys.c
+++ b/src/c2ixys.c
@@ -47,7 +47,7 @@ void eraC2ixys(double x, double y, double s, double rc2i[3][3])
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -56,7 +56,7 @@ void eraC2ixys(double x, double y, double s, double rc2i[3][3])
 
 /* Obtain the spherical angles E and d. */
    r2 = x*x + y*y;
-   e = (r2 != 0.0) ? atan2(y, x) : 0.0;
+   e = (r2 > 0.0) ? atan2(y, x) : 0.0;
    d = atan(sqrt(r2 / (1.0 - r2)));
 
 /* Form the matrix. */
@@ -71,7 +71,7 @@ void eraC2ixys(double x, double y, double s, double rc2i[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/c2s.c
+++ b/src/c2s.c
@@ -23,12 +23,11 @@ void eraC2s(double p[3], double *theta, double *phi)
 **
 **  3) At either pole, zero theta is returned.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double x, y, z, d2;
-
 
    x  = p[0];
    y  = p[1];
@@ -44,7 +43,7 @@ void eraC2s(double p[3], double *theta, double *phi)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/c2t00a.c
+++ b/src/c2t00a.c
@@ -74,12 +74,11 @@ void eraC2t00a(double tta, double ttb, double uta, double utb,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double rc2i[3][3], era, sp, rpom[3][3];
-
 
 /* Form the celestial-to-intermediate matrix for this TT (IAU 2000A). */
    eraC2i00a(tta, ttb, rc2i );
@@ -102,7 +101,7 @@ void eraC2t00a(double tta, double ttb, double uta, double utb,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/c2t00b.c
+++ b/src/c2t00b.c
@@ -73,12 +73,11 @@ void eraC2t00b(double tta, double ttb, double uta, double utb,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double rc2i[3][3], era, rpom[3][3];
-
 
 /* Form the celestial-to-intermediate matrix for this TT (IAU 2000B). */
    eraC2i00b(tta, ttb, rc2i);
@@ -98,7 +97,7 @@ void eraC2t00b(double tta, double ttb, double uta, double utb,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/c2t06a.c
+++ b/src/c2t06a.c
@@ -72,12 +72,11 @@ void eraC2t06a(double tta, double ttb, double uta, double utb,
 **     McCarthy, D. D., Petit, G. (eds.), 2004, IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double rc2i[3][3], era, sp, rpom[3][3];
-
 
 /* Form the celestial-to-intermediate matrix for this TT. */
    eraC2i06a(tta, ttb, rc2i);
@@ -100,7 +99,7 @@ void eraC2t06a(double tta, double ttb, double uta, double utb,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/c2tcio.c
+++ b/src/c2tcio.c
@@ -52,12 +52,11 @@ void eraC2tcio(double rc2i[3][3], double era, double rpom[3][3],
 **     McCarthy, D. D., Petit, G. (eds.), 2004, IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double r[3][3];
-
 
 /* Construct the matrix. */
    eraCr(rc2i, r);
@@ -70,7 +69,7 @@ void eraC2tcio(double rc2i[3][3], double era, double rpom[3][3],
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/c2teqx.c
+++ b/src/c2teqx.c
@@ -52,12 +52,11 @@ void eraC2teqx(double rbpn[3][3], double gst, double rpom[3][3],
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double r[3][3];
-
 
 /* Construct the matrix. */
    eraCr(rbpn, r);
@@ -70,7 +69,7 @@ void eraC2teqx(double rbpn[3][3], double gst, double rpom[3][3],
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/c2tpe.c
+++ b/src/c2tpe.c
@@ -83,13 +83,12 @@ void eraC2tpe(double tta, double ttb, double uta, double utb,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double epsa, rb[3][3], rp[3][3], rbp[3][3], rn[3][3],
           rbpn[3][3], gmst, ee, sp, rpom[3][3];
-
 
 /* Form the celestial-to-true matrix for this TT. */
    eraPn00(tta, ttb, dpsi, deps, &epsa, rb, rp, rbp, rn, rbpn);
@@ -115,7 +114,7 @@ void eraC2tpe(double tta, double ttb, double uta, double utb,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/c2txy.c
+++ b/src/c2txy.c
@@ -79,12 +79,11 @@ void eraC2txy(double tta, double ttb, double uta, double utb,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double rc2i[3][3], era, sp, rpom[3][3];
-
 
 /* Form the celestial-to-intermediate matrix for this TT. */
    eraC2ixy(tta, ttb, x, y, rc2i);
@@ -107,7 +106,7 @@ void eraC2txy(double tta, double ttb, double uta, double utb,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/cal2jd.c
+++ b/src/cal2jd.c
@@ -43,7 +43,7 @@ int eraCal2jd(int iy, int im, int id, double *djm0, double *djm)
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 12.92 (p604).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -56,7 +56,6 @@ int eraCal2jd(int iy, int im, int id, double *djm0, double *djm)
 /* Month lengths in days */
    static const int mtab[]
                      = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
-
 
 /* Preset status. */
    j = 0;
@@ -87,7 +86,7 @@ int eraCal2jd(int iy, int im, int id, double *djm0, double *djm)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/cp.c
+++ b/src/cp.c
@@ -14,7 +14,7 @@ void eraCp(double p[3], double c[3])
 **  Returned:
 **     c        double[3]     copy
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -28,7 +28,7 @@ void eraCp(double p[3], double c[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/cpv.c
+++ b/src/cpv.c
@@ -17,7 +17,7 @@ void eraCpv(double pv[2][3], double c[2][3])
 **  Called:
 **     eraCp        copy p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -30,7 +30,7 @@ void eraCpv(double pv[2][3], double c[2][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/cr.c
+++ b/src/cr.c
@@ -17,7 +17,7 @@ void eraCr(double r[3][3], double c[3][3])
 **  Called:
 **     eraCp        copy p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -31,7 +31,7 @@ void eraCr(double r[3][3], double c[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/d2dtf.c
+++ b/src/d2dtf.c
@@ -71,7 +71,7 @@ int eraD2dtf(const char *scale, int ndp, double d1, double d2,
 **     eraD2tf      decompose days to hms
 **     eraDat       delta(AT) = TAI-UTC
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -79,7 +79,6 @@ int eraD2dtf(const char *scale, int ndp, double d1, double d2,
    char s;
    int iy1, im1, id1, js, iy2, im2, id2, ihmsf1[4], i;
    double a1, b1, fd, dat0, dat12, w, dat24, dleap;
-
 
 /* The two-part JD. */
    a1 = d1;
@@ -184,7 +183,7 @@ int eraD2dtf(const char *scale, int ndp, double d1, double d2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/d2tf.c
+++ b/src/d2tf.c
@@ -48,13 +48,12 @@ void eraD2tf(int ndp, double days, char *sign, int ihmsf[4])
 **     case where days is very nearly 1.0 and rounds up to 24 hours,
 **     by testing for ihmsf[0]=24 and setting ihmsf[0-3] to zero.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int nrs, n;
    double rs, rm, rh, a, w, ah, am, as, af;
-
 
 /* Handle sign. */
    *sign = (char) ( ( days >= 0.0 ) ? '+' : '-' );
@@ -108,7 +107,7 @@ void eraD2tf(int ndp, double days, char *sign, int ihmsf[4])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/dat.c
+++ b/src/dat.c
@@ -36,7 +36,7 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
 **     :  even if no leap seconds have been       :
 **     :  added.                                  :
 **     :                                          :
-**     :  Latest leap second:  2012 June 30       :
+**     :  Latest leap second:  2015 June 30       :
 **     :                                          :
 **     :__________________________________________:
 **
@@ -115,12 +115,12 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
 **  Called:
 **     eraCal2jd    Gregorian calendar to JD
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
 /* Release year for this version of eraDat */
-   enum { IYV = 2014};
+   enum { IYV = 2015};
 
 /* Reference dates (MJD) and drift rates (s/day), pre leap seconds */
    static const double drift[][2] = {
@@ -187,11 +187,12 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
       { 1999,  1, 32.0       },
       { 2006,  1, 33.0       },
       { 2009,  1, 34.0       },
-      { 2012,  7, 35.0       }
+      { 2012,  7, 35.0       },
+      { 2015,  7, 36.0       }
    };
 
 /* Number of Delta(AT) changes */
-   enum { NDAT = (int) (sizeof changes / sizeof changes[0]) };
+   const int NDAT = sizeof changes / sizeof changes[0];
 
 /* Miscellaneous local variables */
    int j, i, m;
@@ -228,7 +229,7 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
    if (i < 0) return -5;
 
 /* Get the Delta(AT). */
-   da = changes[(i < 0) ? 0 : i].delat;
+   da = changes[i].delat;
 
 /* If pre-1972, adjust for drift. */
    if (i < NERA1) da += (djm + fd - drift[i][0]) * drift[i][1];
@@ -243,7 +244,7 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/dat.c
+++ b/src/dat.c
@@ -57,7 +57,7 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
 **                      -2 = bad month
 **                      -3 = bad day (Note 3)
 **                      -4 = bad fraction (Note 4)
-**                      -5 = internal error
+**                      -5 = internal error (Note 5)
 **
 **  Notes:
 **
@@ -192,7 +192,7 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
    };
 
 /* Number of Delta(AT) changes */
-   const int NDAT = sizeof changes / sizeof changes[0];
+   enum { NDAT = (int) (sizeof changes / sizeof changes[0]) };
 
 /* Miscellaneous local variables */
    int j, i, m;

--- a/src/dtdb.c
+++ b/src/dtdb.c
@@ -157,7 +157,7 @@ double eraDtdb(double date1, double date2,
 **     Simon, J.L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G. & Laskar, J., Astron.Astrophys., 282, 663-683 (1994).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -1061,7 +1061,6 @@ double eraDtdb(double date1, double date2,
       {    0.000209e-6,      155.420399434,  1.989815753 }
    };
 
-
 /* Time since J2000.0 in Julian millennia. */
    t = ((date1 - ERFA_DJ00) + date2) / ERFA_DJM;
 
@@ -1161,7 +1160,7 @@ double eraDtdb(double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/dtf2d.c
+++ b/src/dtf2d.c
@@ -75,13 +75,12 @@ int eraDtf2d(const char *scale, int iy, int im, int id,
 **     eraDat       delta(AT) = TAI-UTC
 **     eraJd2cal    JD to Gregorian calendar
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int js, iy2, im2, id2;
    double dj, w, day, seclim, dat0, dat12, dat24, dleap, time;
-
 
 /* Today's Julian Day Number. */
    js = eraCal2jd(iy, im, id, &dj, &w);
@@ -151,7 +150,7 @@ int eraDtf2d(const char *scale, int iy, int im, int id,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/ee00.c
+++ b/src/ee00.c
@@ -60,12 +60,11 @@ double eraEe00(double date1, double date2, double epsa, double dpsi)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double ee;
-
 
 /* Equation of the equinoxes. */
    ee = dpsi * cos(epsa) + eraEect00(date1, date2);
@@ -76,7 +75,7 @@ double eraEe00(double date1, double date2, double epsa, double dpsi)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/ee00a.c
+++ b/src/ee00a.c
@@ -58,12 +58,11 @@ double eraEe00a(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double dpsipr, depspr, epsa, dpsi, deps, ee;
-
 
 /* IAU 2000 precession-rate adjustments. */
    eraPr00(date1, date2, &dpsipr, &depspr);
@@ -83,7 +82,7 @@ double eraEe00a(double date1, double date2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/ee00b.c
+++ b/src/ee00b.c
@@ -64,12 +64,11 @@ double eraEe00b(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double dpsipr, depspr, epsa, dpsi, deps, ee;
-
 
 /* IAU 2000 precession-rate adjustments. */
    eraPr00(date1, date2, &dpsipr, &depspr);
@@ -89,7 +88,7 @@ double eraEe00b(double date1, double date2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/ee06a.c
+++ b/src/ee06a.c
@@ -50,12 +50,11 @@ double eraEe06a(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), 2004, IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double gst06a, gmst06, ee;
-
 
 /* Apparent and mean sidereal times. */
    gst06a = eraGst06a(0.0, 0.0, date1, date2);
@@ -70,7 +69,7 @@ double eraEe06a(double date1, double date2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/eect00.c
+++ b/src/eect00.c
@@ -91,7 +91,7 @@ double eraEect00(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -230,7 +230,7 @@ double eraEect00(double date1, double date2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/eform.c
+++ b/src/eform.c
@@ -55,7 +55,7 @@ int eraEform ( int n, double *a, double *f )
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     p220.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -94,7 +94,7 @@ int eraEform ( int n, double *a, double *f )
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/eo06a.c
+++ b/src/eo06a.c
@@ -54,12 +54,11 @@ double eraEo06a(double date1, double date2)
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double r[3][3], x, y, s, eo;
-
 
 /* Classical nutation x precession x bias matrix. */
    eraPnm06a(date1, date2, r);
@@ -79,7 +78,7 @@ double eraEo06a(double date1, double date2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/eors.c
+++ b/src/eors.c
@@ -33,12 +33,11 @@ double eraEors(double rnpb[3][3], double s)
 **
 **     Wallace, P. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double x, ax, xs, ys, zs, p, q, eo;
-
 
 /* Evaluate Wallace & Capitaine (2006) expression (16). */
    x = rnpb[2][0];
@@ -56,7 +55,7 @@ double eraEors(double rnpb[3][3], double s)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/epb.c
+++ b/src/epb.c
@@ -26,7 +26,7 @@ double eraEpb(double dj1, double dj2)
 **
 **     Lieske, J.H., 1979. Astron.Astrophys., 73, 282.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -39,7 +39,7 @@ double eraEpb(double dj1, double dj2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/epb2jd.c
+++ b/src/epb2jd.c
@@ -26,7 +26,7 @@ void eraEpb2jd(double epb, double *djm0, double *djm)
 **
 **     Lieske, J.H., 1979, Astron.Astrophys. 73, 282.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -39,7 +39,7 @@ void eraEpb2jd(double epb, double *djm0, double *djm)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/epj.c
+++ b/src/epj.c
@@ -26,12 +26,11 @@ double eraEpj(double dj1, double dj2)
 **
 **     Lieske, J.H., 1979, Astron.Astrophys. 73, 282.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double epj;
-
 
    epj = 2000.0 + ((dj1 - ERFA_DJ00) + dj2) / ERFA_DJY;
 
@@ -41,7 +40,7 @@ double eraEpj(double dj1, double dj2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/epj2jd.c
+++ b/src/epj2jd.c
@@ -26,7 +26,7 @@ void eraEpj2jd(double epj, double *djm0, double *djm)
 **
 **     Lieske, J.H., 1979, Astron.Astrophys. 73, 282.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -39,7 +39,7 @@ void eraEpj2jd(double epj, double *djm0, double *djm)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/epv00.c
+++ b/src/epv00.c
@@ -94,7 +94,7 @@ int eraEpv00(double date1, double date2,
 **  5) It is permissible to use the same array for pvh and pvb, which
 **     will receive the barycentric values.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -2537,7 +2537,7 @@ int eraEpv00(double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/eqeq94.c
+++ b/src/eqeq94.c
@@ -51,12 +51,11 @@ double eraEqeq94(double date1, double date2)
 **     Capitaine, N. & Gontier, A.-M., 1993, Astron. Astrophys., 275,
 **     645-650.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double t,  om,  dpsi,  deps,  eps0, ee;
-
 
 /* Interval between fundamental epoch J2000.0 and given date (JC). */
    t = ((date1 - ERFA_DJ00) + date2) / ERFA_DJC;
@@ -80,7 +79,7 @@ double eraEqeq94(double date1, double date2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/era00.c
+++ b/src/era00.c
@@ -54,12 +54,11 @@ double eraEra00(double dj1, double dj2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double d1, d2, t, f, theta;
-
 
 /* Days since fundamental epoch. */
    if (dj1 < dj2) {
@@ -84,7 +83,7 @@ double eraEra00(double dj1, double dj2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/erfa.h
+++ b/src/erfa.h
@@ -8,7 +8,7 @@
 **
 **  Prototype function declarations for ERFA library.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 
@@ -129,6 +129,8 @@ int eraPmsafe(double ra1, double dec1, double pmr1, double pmd1,
               double ep1a, double ep1b, double ep2a, double ep2b,
               double *ra2, double *dec2, double *pmr2, double *pmd2,
               double *px2, double *rv2);
+void eraPvtob(double elong, double phi, double height, double xp,
+              double yp, double sp, double theta, double pv[2][3]);
 void eraRefco(double phpa, double tc, double rh, double wl,
               double *refa, double *refb);
 
@@ -277,10 +279,6 @@ double eraGst06a(double uta, double utb, double tta, double ttb);
 double eraGst94(double uta, double utb);
 
 /* Astronomy/SpaceMotion */
-int eraPmsafe(double ra1, double dec1, double pmr1, double pmd1,
-              double px1, double rv1, double ep1a, double ep1b,
-              double ep2a, double ep2b, double *ra2, double *dec2,
-              double *pmr2, double *pmd2, double *px2, double *rv2);
 int eraPvstar(double pv[2][3], double *ra, double *dec,
               double *pmr, double *pmd, double *px, double *rv);
 int eraStarpv(double ra, double dec,
@@ -307,6 +305,10 @@ int eraStarpm(double ra1, double dec1,
               double *ra2, double *dec2,
               double *pmr2, double *pmd2, double *px2, double *rv2);
 
+/* Astronomy/GalacticCoordinates */
+void eraG2icrs ( double dl, double db, double *dr, double *dd );
+void eraIcrs2g ( double dr, double dd, double *dl, double *db );
+
 /* Astronomy/GeodeticGeocentric */
 int eraEform(int n, double *a, double *f);
 int eraGc2gd(int n, double xyz[3],
@@ -317,8 +319,6 @@ int eraGd2gc(int n, double elong, double phi, double height,
              double xyz[3]);
 int eraGd2gce(double a, double f,
               double elong, double phi, double height, double xyz[3]);
-void eraPvtob(double elong, double phi, double height, double xp,
-              double yp, double sp, double theta, double pv[2][3]);
 
 /* Astronomy/Timescales */
 int eraD2dtf(const char *scale, int ndp, double d1, double d2,
@@ -438,11 +438,11 @@ void eraSxpv(double s, double pv[2][3], double spv[2][3]);
 
 #endif
 
-/* Copyright2 */
+
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/erfam.h
+++ b/src/erfam.h
@@ -8,7 +8,7 @@
 **
 **  Macros used by ERFA library.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 
@@ -147,7 +147,7 @@ typedef struct {
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/fad03.c
+++ b/src/fad03.c
@@ -31,12 +31,11 @@ double eraFad03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double a;
-
 
 /* Mean elongation of the Moon from the Sun (IERS Conventions 2003). */
    a = fmod(          1072260.703692 +
@@ -51,7 +50,7 @@ double eraFad03(double t)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/fae03.c
+++ b/src/fae03.c
@@ -34,12 +34,11 @@ double eraFae03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double a;
-
 
 /* Mean longitude of Earth (IERS Conventions 2003). */
    a = fmod(1.753470314 + 628.3075849991 * t, ERFA_D2PI);
@@ -50,7 +49,7 @@ double eraFae03(double t)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/faf03.c
+++ b/src/faf03.c
@@ -32,12 +32,11 @@ double eraFaf03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double a;
-
 
 /* Mean longitude of the Moon minus that of the ascending node */
 /* (IERS Conventions 2003).                                    */
@@ -49,12 +48,11 @@ double eraFaf03(double t)
 
    return a;
 
-
 }
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/faju03.c
+++ b/src/faju03.c
@@ -34,12 +34,11 @@ double eraFaju03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double a;
-
 
 /* Mean longitude of Jupiter (IERS Conventions 2003). */
    a = fmod(0.599546497 + 52.9690962641 * t, ERFA_D2PI);
@@ -50,7 +49,7 @@ double eraFaju03(double t)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/fal03.c
+++ b/src/fal03.c
@@ -31,12 +31,11 @@ double eraFal03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double a;
-
 
 /* Mean anomaly of the Moon (IERS Conventions 2003). */
    a = fmod(           485868.249036  +
@@ -51,7 +50,7 @@ double eraFal03(double t)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/falp03.c
+++ b/src/falp03.c
@@ -31,12 +31,11 @@ double eraFalp03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double a;
-
 
 /* Mean anomaly of the Sun (IERS Conventions 2003). */
    a = fmod(         1287104.793048 +
@@ -51,7 +50,7 @@ double eraFalp03(double t)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/fama03.c
+++ b/src/fama03.c
@@ -34,12 +34,11 @@ double eraFama03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double a;
-
 
 /* Mean longitude of Mars (IERS Conventions 2003). */
    a = fmod(6.203480913 + 334.0612426700 * t, ERFA_D2PI);
@@ -50,7 +49,7 @@ double eraFama03(double t)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/fame03.c
+++ b/src/fame03.c
@@ -34,12 +34,11 @@ double eraFame03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double a;
-
 
 /* Mean longitude of Mercury (IERS Conventions 2003). */
    a = fmod(4.402608842 + 2608.7903141574 * t, ERFA_D2PI);
@@ -50,7 +49,7 @@ double eraFame03(double t)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/fane03.c
+++ b/src/fane03.c
@@ -31,12 +31,11 @@ double eraFane03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double a;
-
 
 /* Mean longitude of Neptune (IERS Conventions 2003). */
    a = fmod(5.311886287 + 3.8133035638 * t, ERFA_D2PI);
@@ -47,7 +46,7 @@ double eraFane03(double t)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/faom03.c
+++ b/src/faom03.c
@@ -31,12 +31,11 @@ double eraFaom03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double a;
-
 
 /* Mean longitude of the Moon's ascending node */
 /* (IERS Conventions 2003).                    */
@@ -52,7 +51,7 @@ double eraFaom03(double t)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/fapa03.c
+++ b/src/fapa03.c
@@ -35,12 +35,11 @@ double eraFapa03(double t)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double a;
-
 
 /* General accumulated precession in longitude. */
    a = (0.024381750 + 0.00000538691 * t) * t;
@@ -51,7 +50,7 @@ double eraFapa03(double t)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/fasa03.c
+++ b/src/fasa03.c
@@ -34,12 +34,11 @@ double eraFasa03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double a;
-
 
 /* Mean longitude of Saturn (IERS Conventions 2003). */
    a = fmod(0.874016757 + 21.3299104960 * t, ERFA_D2PI);
@@ -50,7 +49,7 @@ double eraFasa03(double t)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/faur03.c
+++ b/src/faur03.c
@@ -31,12 +31,11 @@ double eraFaur03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double a;
-
 
 /* Mean longitude of Uranus (IERS Conventions 2003). */
    a = fmod(5.481293872 + 7.4781598567 * t, ERFA_D2PI);
@@ -47,7 +46,7 @@ double eraFaur03(double t)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/fave03.c
+++ b/src/fave03.c
@@ -34,12 +34,11 @@ double eraFave03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double a;
-
 
 /* Mean longitude of Venus (IERS Conventions 2003). */
    a = fmod(3.176146697 + 1021.3285546211 * t, ERFA_D2PI);
@@ -50,7 +49,7 @@ double eraFave03(double t)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/fk52h.c
+++ b/src/fk52h.c
@@ -53,13 +53,12 @@ void eraFk52h(double r5, double d5,
 **
 **     F.Mignard & M.Froeschle, Astron. Astrophys. 354, 732-739 (2000).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int i;
    double pv5[2][3], r5h[3][3], s5h[3], wxp[3], vv[3], pvh[2][3];
-
 
 /* FK5 barycentric position/velocity pv-vector (normalized). */
    eraStarpv(r5, d5, dr5, dd5, px5, rv5, pv5);
@@ -91,7 +90,7 @@ void eraFk52h(double r5, double d5,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/fk5hip.c
+++ b/src/fk5hip.c
@@ -36,7 +36,7 @@ void eraFk5hip(double r5h[3][3], double s5h[3])
 **
 **     F.Mignard & M.Froeschle, Astron. Astrophys. 354, 732-739 (2000).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -45,7 +45,6 @@ void eraFk5hip(double r5h[3][3], double s5h[3])
 /* FK5 wrt Hipparcos orientation and spin (radians, radians/year) */
    double epx, epy, epz;
    double omx, omy, omz;
-
 
    epx = -19.9e-3 * ERFA_DAS2R;
    epy =  -9.1e-3 * ERFA_DAS2R;
@@ -74,7 +73,7 @@ void eraFk5hip(double r5h[3][3], double s5h[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/fk5hz.c
+++ b/src/fk5hz.c
@@ -69,13 +69,12 @@ void eraFk5hz(double r5, double d5, double date1, double date2,
 **
 **     F.Mignard & M.Froeschle, 2000, Astron.Astrophys. 354, 732-739.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double t, p5e[3], r5h[3][3], s5h[3], vst[3], rst[3][3], p5[3],
           ph[3], w;
-
 
 /* Interval from given date to fundamental epoch J2000.0 (JY). */
    t = - ((date1 - ERFA_DJ00) + date2) / ERFA_DJY;
@@ -108,7 +107,7 @@ void eraFk5hz(double r5, double d5, double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/fw2m.c
+++ b/src/fw2m.c
@@ -65,7 +65,7 @@ void eraFw2m(double gamb, double phib, double psi, double eps,
 **
 **     Hilton, J. et al., 2006, Celest.Mech.Dyn.Astron. 94, 351
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -82,7 +82,7 @@ void eraFw2m(double gamb, double phib, double psi, double eps,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/fw2xy.c
+++ b/src/fw2xy.c
@@ -50,12 +50,11 @@ void eraFw2xy(double gamb, double phib, double psi, double eps,
 **
 **     Hilton, J. et al., 2006, Celest.Mech.Dyn.Astron. 94, 351
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double r[3][3];
-
 
 /* Form NxPxB matrix. */
    eraFw2m(gamb, phib, psi, eps, r);
@@ -69,7 +68,7 @@ void eraFw2xy(double gamb, double phib, double psi, double eps,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/g2icrs.c
+++ b/src/g2icrs.c
@@ -1,0 +1,170 @@
+#include "erfa.h"
+
+void eraG2icrs ( double dl, double db, double *dr, double *dd )
+/*
+**  - - - - - - - - - -
+**   e r a G 2 i c r s
+**  - - - - - - - - - -
+**
+**  Transformation from Galactic Coordinates to ICRS.
+**
+**  Given:
+**     dl     double      galactic longitude (radians)
+**     db     double      galactic latitude (radians)
+**
+**  Returned:
+**     dr     double      ICRS right ascension (radians)
+**     dd     double      ICRS declination (radians)
+**
+**  Notes:
+**
+**  1) The IAU 1958 system of Galactic coordinates was defined with
+**     respect to the now obsolete reference system FK4 B1950.0.  When
+**     interpreting the system in a modern context, several factors have
+**     to be taken into account:
+**
+**     . The inclusion in FK4 positions of the E-terms of aberration.
+**
+**     . The distortion of the FK4 proper motion system by differential
+**       Galactic rotation.
+**
+**     . The use of the B1950.0 equinox rather than the now-standard
+**       J2000.0.
+**
+**     . The frame bias between ICRS and the J2000.0 mean place system.
+**
+**     The Hipparcos Catalogue (Perryman & ESA 1997) provides a rotation
+**     matrix that transforms directly between ICRS and Galactic
+**     coordinates with the above factors taken into account.  The
+**     matrix is derived from three angles, namely the ICRS coordinates
+**     of the Galactic pole and the longitude of the ascending node of
+**     the galactic equator on the ICRS equator.  They are given in
+**     degrees to five decimal places and for canonical purposes are
+**     regarded as exact.  In the Hipparcos Catalogue the matrix
+**     elements are given to 10 decimal places (about 20 microarcsec).
+**     In the present ERFA function the matrix elements have been
+**     recomputed from the canonical three angles and are given to 30
+**     decimal places.
+**
+**  2) The inverse transformation is performed by the function eraIcrs2g.
+**
+**  Called:
+**     eraAnp       normalize angle into range 0 to 2pi
+**     eraAnpm      normalize angle into range +/- pi
+**     eraS2c       spherical coordinates to unit vector
+**     eraTrxp      product of transpose of r-matrix and p-vector
+**     eraC2s       p-vector to spherical
+**
+**  Reference:
+**     Perryman M.A.C. & ESA, 1997, ESA SP-1200, The Hipparcos and Tycho
+**     catalogues.  Astrometric and photometric star catalogues
+**     derived from the ESA Hipparcos Space Astrometry Mission.  ESA
+**     Publications Division, Noordwijk, Netherlands.
+**
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
+**  Derived, with permission, from the SOFA library.  See notes at end of file.
+*/
+{
+   double v1[3], v2[3];
+
+/*
+**  L2,B2 system of galactic coordinates in the form presented in the
+**  Hipparcos Catalogue.  In degrees:
+**
+**  P = 192.85948    right ascension of the Galactic north pole in ICRS
+**  Q =  27.12825    declination of the Galactic north pole in ICRS
+**  R =  32.93192    longitude of the ascending node of the Galactic
+**                   plane on the ICRS equator
+**
+**  ICRS to galactic rotation matrix, obtained by computing
+**  R_3(-R) R_1(pi/2-Q) R_3(pi/2+P) to the full precision shown:
+*/
+   double r[3][3] = { { -0.054875560416215368492398900454,
+                        -0.873437090234885048760383168409,
+                        -0.483835015548713226831774175116 },
+                      { +0.494109427875583673525222371358,
+                        -0.444829629960011178146614061616,
+                        +0.746982244497218890527388004556 },
+                      { -0.867666149019004701181616534570,
+                        -0.198076373431201528180486091412,
+                        +0.455983776175066922272100478348 } };
+
+
+/* Spherical to Cartesian. */
+   eraS2c(dl, db, v1);
+
+/* Galactic to ICRS. */
+   eraTrxp(r, v1, v2);
+
+/* Cartesian to spherical. */
+   eraC2s(v2, dr, dd);
+
+/* Express in conventional ranges. */
+   *dr = eraAnp(*dr);
+   *dd = eraAnpm(*dd);
+
+/* Finished. */
+
+}
+/*----------------------------------------------------------------------
+**  
+**  
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
+**  All rights reserved.
+**  
+**  This library is derived, with permission, from the International
+**  Astronomical Union's "Standards of Fundamental Astronomy" library,
+**  available from http://www.iausofa.org.
+**  
+**  The ERFA version is intended to retain identical functionality to
+**  the SOFA library, but made distinct through different function and
+**  file names, as set out in the SOFA license conditions.  The SOFA
+**  original has a role as a reference standard for the IAU and IERS,
+**  and consequently redistribution is permitted only in its unaltered
+**  state.  The ERFA version is not subject to this restriction and
+**  therefore can be included in distributions which do not support the
+**  concept of "read only" software.
+**  
+**  Although the intent is to replicate the SOFA API (other than
+**  replacement of prefix names) and results (with the exception of
+**  bugs;  any that are discovered will be fixed), SOFA is not
+**  responsible for any errors found in this version of the library.
+**  
+**  If you wish to acknowledge the SOFA heritage, please acknowledge
+**  that you are using a library derived from SOFA, rather than SOFA
+**  itself.
+**  
+**  
+**  TERMS AND CONDITIONS
+**  
+**  Redistribution and use in source and binary forms, with or without
+**  modification, are permitted provided that the following conditions
+**  are met:
+**  
+**  1 Redistributions of source code must retain the above copyright
+**    notice, this list of conditions and the following disclaimer.
+**  
+**  2 Redistributions in binary form must reproduce the above copyright
+**    notice, this list of conditions and the following disclaimer in
+**    the documentation and/or other materials provided with the
+**    distribution.
+**  
+**  3 Neither the name of the Standards Of Fundamental Astronomy Board,
+**    the International Astronomical Union nor the names of its
+**    contributors may be used to endorse or promote products derived
+**    from this software without specific prior written permission.
+**  
+**  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+**  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+**  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+**  FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+**  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+**  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+**  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+**  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+**  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+**  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+**  POSSIBILITY OF SUCH DAMAGE.
+**  
+*/

--- a/src/gc2gd.c
+++ b/src/gc2gd.c
@@ -51,13 +51,12 @@ int eraGc2gd ( int n, double xyz[3],
 **     eraEform     Earth reference ellipsoids
 **     eraGc2gde    geocentric to geodetic transformation, general
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int j;
    double a, f;
-
 
 /* Obtain reference ellipsoid parameters. */
    j = eraEform ( n, &a, &f );
@@ -82,7 +81,7 @@ int eraGc2gd ( int n, double xyz[3],
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/gc2gde.c
+++ b/src/gc2gde.c
@@ -56,7 +56,7 @@ int eraGc2gde ( double a, double f, double xyz[3],
 **     coordinates accelerated by Halley's method", J.Geodesy (2006)
 **     79: 689-693
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -91,7 +91,7 @@ int eraGc2gde ( double a, double f, double xyz[3],
    p2 = x*x + y*y;
 
 /* Longitude. */
-   *elong = p2 != 0.0 ? atan2(y, x) : 0.0;
+   *elong = p2 > 0.0 ? atan2(y, x) : 0.0;
 
 /* Unsigned z-coordinate. */
    absz = fabs(z);
@@ -147,7 +147,7 @@ int eraGc2gde ( double a, double f, double xyz[3],
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/gd2gc.c
+++ b/src/gd2gc.c
@@ -54,13 +54,12 @@ int eraGd2gc ( int n, double elong, double phi, double height,
 **     eraGd2gce    geodetic to geocentric transformation, general
 **     eraZp        zero p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int j;
    double a, f;
-
 
 /* Obtain reference ellipsoid parameters. */
    j = eraEform ( n, &a, &f );
@@ -81,7 +80,7 @@ int eraGd2gc ( int n, double elong, double phi, double height,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/gd2gce.c
+++ b/src/gd2gce.c
@@ -55,12 +55,11 @@ int eraGd2gce ( double a, double f, double elong, double phi,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 4.22, p202.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double sp, cp, w, d, ac, as, r;
-
 
 /* Functions of geodetic latitude. */
    sp = sin(phi);
@@ -85,7 +84,7 @@ int eraGd2gce ( double a, double f, double elong, double phi,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/gmst00.c
+++ b/src/gmst00.c
@@ -68,12 +68,11 @@ double eraGmst00(double uta, double utb, double tta, double ttb)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double t, gmst;
-
 
 /* TT Julian centuries since J2000.0. */
    t = ((tta - ERFA_DJ00) + ttb) / ERFA_DJC;
@@ -93,7 +92,7 @@ double eraGmst00(double uta, double utb, double tta, double ttb)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/gmst06.c
+++ b/src/gmst06.c
@@ -58,12 +58,11 @@ double eraGmst06(double uta, double utb, double tta, double ttb)
 **     Capitaine, N., Wallace, P.T. & Chapront, J., 2005,
 **     Astron.Astrophys. 432, 355
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double t, gmst;
-
 
 /* TT Julian centuries since J2000.0. */
    t = ((tta - ERFA_DJ00) + ttb) / ERFA_DJC;
@@ -84,7 +83,7 @@ double eraGmst06(double uta, double utb, double tta, double ttb)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/gmst82.c
+++ b/src/gmst82.c
@@ -60,7 +60,7 @@ double eraGmst82(double dj1, double dj2)
 **
 **     Aoki et al., Astron. Astrophys. 105, 359-361 (1982).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -75,7 +75,6 @@ double eraGmst82(double dj1, double dj2)
 /* at noon.                                                    */
 
    double d1, d2, t, f, gmst;
-
 
 /* Julian centuries since fundamental epoch. */
    if (dj1 < dj2) {
@@ -99,7 +98,7 @@ double eraGmst82(double dj1, double dj2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/gst00a.c
+++ b/src/gst00a.c
@@ -69,12 +69,11 @@ double eraGst00a(double uta, double utb, double tta, double ttb)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double gmst00, ee00a, gst;
-
 
    gmst00 = eraGmst00(uta, utb, tta, ttb);
    ee00a = eraEe00a(tta, ttb);
@@ -86,7 +85,7 @@ double eraGst00a(double uta, double utb, double tta, double ttb)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/gst00b.c
+++ b/src/gst00b.c
@@ -77,12 +77,11 @@ double eraGst00b(double uta, double utb)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double gmst00, ee00b, gst;
-
 
    gmst00 = eraGmst00(uta, utb, uta, utb);
    ee00b = eraEe00b(uta, utb);
@@ -94,7 +93,7 @@ double eraGst00b(double uta, double utb)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/gst06.c
+++ b/src/gst06.c
@@ -64,12 +64,11 @@ double eraGst06(double uta, double utb, double tta, double ttb,
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double x, y, s, era, eors, gst;
-
 
 /* Extract CIP coordinates. */
    eraBpn2xy(rnpb, &x, &y);
@@ -88,7 +87,7 @@ double eraGst06(double uta, double utb, double tta, double ttb,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/gst06a.c
+++ b/src/gst06a.c
@@ -60,12 +60,11 @@ double eraGst06a(double uta, double utb, double tta, double ttb)
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double rnpb[3][3], gst;
-
 
 /* Classical nutation x precession x bias matrix, IAU 2000A. */
    eraPnm06a(tta, ttb, rnpb);
@@ -79,7 +78,7 @@ double eraGst06a(double uta, double utb, double tta, double ttb)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/gst94.c
+++ b/src/gst94.c
@@ -62,12 +62,11 @@ double eraGst94(double uta, double utb)
 **
 **     IAU Resolution C7, Recommendation 3 (1994)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double gmst82, eqeq94, gst;
-
 
    gmst82 = eraGmst82(uta, utb);
    eqeq94 = eraEqeq94(uta, utb);
@@ -79,7 +78,7 @@ double eraGst94(double uta, double utb)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/h2fk5.c
+++ b/src/h2fk5.c
@@ -55,13 +55,12 @@ void eraH2fk5(double rh, double dh,
 **
 **     F.Mignard & M.Froeschle, Astron. Astrophys. 354, 732-739 (2000).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int i;
    double pvh[2][3], r5h[3][3], s5h[3], sh[3], wxp[3], vv[3], pv5[2][3];
-
 
 /* Hipparcos barycentric position/velocity pv-vector (normalized). */
    eraStarpv(rh, dh, drh, ddh, pxh, rvh, pvh);
@@ -96,7 +95,7 @@ void eraH2fk5(double rh, double dh,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/hfk5z.c
+++ b/src/hfk5z.c
@@ -74,14 +74,13 @@ void eraHfk5z(double rh, double dh, double date1, double date2,
 **
 **     F.Mignard & M.Froeschle, 2000, Astron.Astrophys. 354, 732-739.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double t, ph[3], r5h[3][3], s5h[3], sh[3], vst[3],
    rst[3][3], r5ht[3][3], pv5e[2][3], vv[3],
    w, r, v;
-
 
 /* Time interval from fundamental epoch J2000.0 to given date (JY). */
    t = ((date1 - ERFA_DJ00) + date2) / ERFA_DJY;
@@ -123,7 +122,7 @@ void eraHfk5z(double rh, double dh, double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/icrs2g.c
+++ b/src/icrs2g.c
@@ -1,0 +1,170 @@
+#include "erfa.h"
+
+void eraIcrs2g ( double dr, double dd, double *dl, double *db )
+/*
+**  - - - - - - - - - -
+**   e r a I c r s 2 g
+**  - - - - - - - - - -
+**
+**  Transformation from ICRS to Galactic Coordinates.
+**
+**  Given:
+**     dr     double      ICRS right ascension (radians)
+**     dd     double      ICRS declination (radians)
+**
+**  Returned:
+**     dl     double      galactic longitude (radians)
+**     db     double      galactic latitude (radians)
+**
+**  Notes:
+**
+**  1) The IAU 1958 system of Galactic coordinates was defined with
+**     respect to the now obsolete reference system FK4 B1950.0.  When
+**     interpreting the system in a modern context, several factors have
+**     to be taken into account:
+**
+**     . The inclusion in FK4 positions of the E-terms of aberration.
+**
+**     . The distortion of the FK4 proper motion system by differential
+**       Galactic rotation.
+**
+**     . The use of the B1950.0 equinox rather than the now-standard
+**       J2000.0.
+**
+**     . The frame bias between ICRS and the J2000.0 mean place system.
+**
+**     The Hipparcos Catalogue (Perryman & ESA 1997) provides a rotation
+**     matrix that transforms directly between ICRS and Galactic
+**     coordinates with the above factors taken into account.  The
+**     matrix is derived from three angles, namely the ICRS coordinates
+**     of the Galactic pole and the longitude of the ascending node of
+**     the galactic equator on the ICRS equator.  They are given in
+**     degrees to five decimal places and for canonical purposes are
+**     regarded as exact.  In the Hipparcos Catalogue the matrix
+**     elements are given to 10 decimal places (about 20 microarcsec).
+**     In the present ERFA function the matrix elements have been
+**     recomputed from the canonical three angles and are given to 30
+**     decimal places.
+**
+**  2) The inverse transformation is performed by the function eraG2icrs.
+**
+**  Called:
+**     eraAnp       normalize angle into range 0 to 2pi
+**     eraAnpm      normalize angle into range +/- pi
+**     eraS2c       spherical coordinates to unit vector
+**     eraRxp       product of r-matrix and p-vector
+**     eraC2s       p-vector to spherical
+**
+**  Reference:
+**     Perryman M.A.C. & ESA, 1997, ESA SP-1200, The Hipparcos and Tycho
+**     catalogues.  Astrometric and photometric star catalogues
+**     derived from the ESA Hipparcos Space Astrometry Mission.  ESA
+**     Publications Division, Noordwijk, Netherlands.
+**
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
+**  Derived, with permission, from the SOFA library.  See notes at end of file.
+*/
+{
+   double v1[3], v2[3];
+
+/*
+**  L2,B2 system of galactic coordinates in the form presented in the
+**  Hipparcos Catalogue.  In degrees:
+**
+**  P = 192.85948    right ascension of the Galactic north pole in ICRS
+**  Q =  27.12825    declination of the Galactic north pole in ICRS
+**  R =  32.93192    longitude of the ascending node of the Galactic
+**                   plane on the ICRS equator
+**
+**  ICRS to galactic rotation matrix, obtained by computing
+**  R_3(-R) R_1(pi/2-Q) R_3(pi/2+P) to the full precision shown:
+*/
+   double r[3][3] = { { -0.054875560416215368492398900454,
+                        -0.873437090234885048760383168409,
+                        -0.483835015548713226831774175116 },
+                      { +0.494109427875583673525222371358,
+                        -0.444829629960011178146614061616,
+                        +0.746982244497218890527388004556 },
+                      { -0.867666149019004701181616534570,
+                        -0.198076373431201528180486091412,
+                        +0.455983776175066922272100478348 } };
+
+
+/* Spherical to Cartesian. */
+   eraS2c(dr, dd, v1);
+
+/* ICRS to Galactic. */
+   eraRxp(r, v1, v2);
+
+/* Cartesian to spherical. */
+   eraC2s(v2, dl, db);
+
+/* Express in conventional ranges. */
+   *dl = eraAnp(*dl);
+   *db = eraAnpm(*db);
+
+/* Finished. */
+
+}
+/*----------------------------------------------------------------------
+**  
+**  
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
+**  All rights reserved.
+**  
+**  This library is derived, with permission, from the International
+**  Astronomical Union's "Standards of Fundamental Astronomy" library,
+**  available from http://www.iausofa.org.
+**  
+**  The ERFA version is intended to retain identical functionality to
+**  the SOFA library, but made distinct through different function and
+**  file names, as set out in the SOFA license conditions.  The SOFA
+**  original has a role as a reference standard for the IAU and IERS,
+**  and consequently redistribution is permitted only in its unaltered
+**  state.  The ERFA version is not subject to this restriction and
+**  therefore can be included in distributions which do not support the
+**  concept of "read only" software.
+**  
+**  Although the intent is to replicate the SOFA API (other than
+**  replacement of prefix names) and results (with the exception of
+**  bugs;  any that are discovered will be fixed), SOFA is not
+**  responsible for any errors found in this version of the library.
+**  
+**  If you wish to acknowledge the SOFA heritage, please acknowledge
+**  that you are using a library derived from SOFA, rather than SOFA
+**  itself.
+**  
+**  
+**  TERMS AND CONDITIONS
+**  
+**  Redistribution and use in source and binary forms, with or without
+**  modification, are permitted provided that the following conditions
+**  are met:
+**  
+**  1 Redistributions of source code must retain the above copyright
+**    notice, this list of conditions and the following disclaimer.
+**  
+**  2 Redistributions in binary form must reproduce the above copyright
+**    notice, this list of conditions and the following disclaimer in
+**    the documentation and/or other materials provided with the
+**    distribution.
+**  
+**  3 Neither the name of the Standards Of Fundamental Astronomy Board,
+**    the International Astronomical Union nor the names of its
+**    contributors may be used to endorse or promote products derived
+**    from this software without specific prior written permission.
+**  
+**  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+**  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+**  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+**  FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+**  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+**  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+**  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+**  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+**  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+**  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+**  POSSIBILITY OF SUCH DAMAGE.
+**  
+*/

--- a/src/ir.c
+++ b/src/ir.c
@@ -11,7 +11,7 @@ void eraIr(double r[3][3])
 **  Returned:
 **     r       double[3][3]    r-matrix
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -31,7 +31,7 @@ void eraIr(double r[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/jd2cal.c
+++ b/src/jd2cal.c
@@ -50,7 +50,7 @@ int eraJd2cal(double dj1, double dj2,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 12.92 (p604).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -60,7 +60,6 @@ int eraJd2cal(double dj1, double dj2,
 
    long jd, l, n, i, k;
    double dj, d1, d2, f1, f2, f, d;
-
 
 /* Verify date is acceptable. */
    dj = dj1 + dj2;
@@ -103,7 +102,7 @@ int eraJd2cal(double dj1, double dj2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/jdcalf.c
+++ b/src/jdcalf.c
@@ -55,13 +55,12 @@ int eraJdcalf(int ndp, double dj1, double dj2, int iymdf[4])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 12.92 (p604).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int j, js;
    double denom, d1, d2, f1, f2, f;
-
 
 /* Denominator of fraction (e.g. 100 for 2 decimal places). */
    if ((ndp >= 0) && (ndp <= 9)) {
@@ -109,7 +108,7 @@ int eraJdcalf(int ndp, double dj1, double dj2, int iymdf[4])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/ld.c
+++ b/src/ld.c
@@ -68,13 +68,12 @@ void eraLd(double bm, double p[3], double q[3], double e[3],
 **     eraPdp       scalar product of two p-vectors
 **     eraPxp       vector product of two p-vectors
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int i;
    double qpe[3], qdqpe, w, eq[3], peq[3];
-
 
 /* q . (q + e). */
    for (i = 0; i < 3; i++) {
@@ -100,7 +99,7 @@ void eraLd(double bm, double p[3], double q[3], double e[3],
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/ldn.c
+++ b/src/ldn.c
@@ -78,7 +78,7 @@ void eraLdn(int n, eraLDBODY b[], double ob[3], double sc[3],
 **     eraPn        decompose p-vector into modulus and direction
 **     eraLd        light deflection by a solar-system body
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -87,7 +87,6 @@ void eraLdn(int n, eraLDBODY b[], double ob[3], double sc[3],
 
    int i;
    double  v[3], dt, ev[3], em, e[3];
-
 
 /* Star direction prior to deflection. */
    eraCp(sc, sn);
@@ -122,7 +121,7 @@ void eraLdn(int n, eraLDBODY b[], double ob[3], double sc[3],
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/ldsun.c
+++ b/src/ldsun.c
@@ -32,7 +32,7 @@ void eraLdsun(double p[3], double e[3], double em, double p1[3])
 **  Called:
 **     eraLd        light deflection by a solar-system body
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -44,7 +44,7 @@ void eraLdsun(double p[3], double e[3], double em, double p1[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/num00a.c
+++ b/src/num00a.c
@@ -52,12 +52,11 @@ void eraNum00a(double date1, double date2, double rmatn[3][3])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.222-3 (p114).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double dpsi, deps, epsa, rb[3][3], rp[3][3], rbp[3][3], rbpn[3][3];
-
 
 /* Obtain the required matrix (discarding other results). */
    eraPn00a(date1, date2,
@@ -69,7 +68,7 @@ void eraNum00a(double date1, double date2, double rmatn[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/num00b.c
+++ b/src/num00b.c
@@ -52,12 +52,11 @@ void eraNum00b(double date1, double date2, double rmatn[3][3])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.222-3 (p114).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double dpsi, deps, epsa, rb[3][3], rp[3][3], rbp[3][3], rbpn[3][3];
-
 
 /* Obtain the required matrix (discarding other results). */
    eraPn00b(date1, date2,
@@ -69,7 +68,7 @@ void eraNum00b(double date1, double date2, double rmatn[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/num06a.c
+++ b/src/num06a.c
@@ -51,12 +51,11 @@ void eraNum06a(double date1, double date2, double rmatn[3][3])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.222-3 (p114).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double eps, dp, de;
-
 
 /* Mean obliquity. */
    eps = eraObl06(date1, date2);
@@ -73,7 +72,7 @@ void eraNum06a(double date1, double date2, double rmatn[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/numat.c
+++ b/src/numat.c
@@ -17,7 +17,6 @@ void eraNumat(double epsa, double dpsi, double deps, double rmatn[3][3])
 **
 **  Notes:
 **
-**
 **  1) The supplied mean obliquity epsa, must be consistent with the
 **     precession-nutation models from which dpsi and deps were obtained.
 **
@@ -41,7 +40,7 @@ void eraNumat(double epsa, double dpsi, double deps, double rmatn[3][3])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.222-3 (p114).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -57,7 +56,7 @@ void eraNumat(double epsa, double dpsi, double deps, double rmatn[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/nut00a.c
+++ b/src/nut00a.c
@@ -148,7 +148,7 @@ void eraNut00a(double date1, double date2, double *dpsi, double *deps)
 **     Wallace, P.T., "Software for Implementing the IAU 2000
 **     Resolutions", in IERS Workshop 5.1 (2002)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -1995,7 +1995,7 @@ void eraNut00a(double date1, double date2, double *dpsi, double *deps)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/nut00b.c
+++ b/src/nut00b.c
@@ -116,7 +116,7 @@ void eraNut00b(double date1, double date2, double *dpsi, double *deps)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J., Astron.Astrophys. 282, 663-683 (1994)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -320,7 +320,7 @@ void eraNut00b(double date1, double date2, double *dpsi, double *deps)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/nut06a.c
+++ b/src/nut06a.c
@@ -75,12 +75,11 @@ void eraNut06a(double date1, double date2, double *dpsi, double *deps)
 **     Wallace, P.T., "Software for Implementing the IAU 2000
 **     Resolutions", in IERS Workshop 5.1 (2002)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double t, fj2, dp, de;
-
 
 /* Interval between fundamental date J2000.0 and given date (JC). */
    t = ((date1 - ERFA_DJ00) + date2) / ERFA_DJC;
@@ -101,7 +100,7 @@ void eraNut06a(double date1, double date2, double *dpsi, double *deps)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/nut80.c
+++ b/src/nut80.c
@@ -48,7 +48,7 @@ void eraNut80(double date1, double date2, double *dpsi, double *deps)
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.222 (p111).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -273,7 +273,7 @@ void eraNut80(double date1, double date2, double *dpsi, double *deps)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/nutm80.c
+++ b/src/nutm80.c
@@ -45,12 +45,11 @@ void eraNutm80(double date1, double date2, double rmatn[3][3])
 **     eraObl80     mean obliquity, IAU 1980
 **     eraNumat     form nutation matrix
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double dpsi, deps, epsa;
-
 
 /* Nutation components and mean obliquity. */
    eraNut80(date1, date2, &dpsi, &deps);
@@ -65,7 +64,7 @@ void eraNutm80(double date1, double date2, double rmatn[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/obl06.c
+++ b/src/obl06.c
@@ -42,12 +42,11 @@ double eraObl06(double date1, double date2)
 **
 **     Hilton, J. et al., 2006, Celest.Mech.Dyn.Astron. 94, 351
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double t, eps0;
-
 
 /* Interval between fundamental date J2000.0 and given date (JC). */
    t = ((date1 - ERFA_DJ00) + date2) / ERFA_DJC;
@@ -66,7 +65,7 @@ double eraObl06(double date1, double date2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/obl80.c
+++ b/src/obl80.c
@@ -44,12 +44,11 @@ double eraObl80(double date1, double date2)
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Expression 3.222-1 (p114).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double t, eps0;
-
 
 /* Interval between fundamental epoch J2000.0 and given date (JC). */
    t = ((date1 - ERFA_DJ00) + date2) / ERFA_DJC;
@@ -66,7 +65,7 @@ double eraObl80(double date1, double date2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/p06e.c
+++ b/src/p06e.c
@@ -120,12 +120,11 @@ void eraP06e(double date1, double date2,
 **  Called:
 **     eraObl06     mean obliquity, IAU 2006
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double t;
-
 
 /* Interval between fundamental date J2000.0 and given date (JC). */
    t = ((date1 - ERFA_DJ00) + date2) / ERFA_DJC;
@@ -269,7 +268,7 @@ void eraP06e(double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/p2pv.c
+++ b/src/p2pv.c
@@ -18,7 +18,7 @@ void eraP2pv(double p[3], double pv[2][3])
 **     eraCp        copy p-vector
 **     eraZp        zero p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -31,7 +31,7 @@ void eraP2pv(double p[3], double pv[2][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/p2s.c
+++ b/src/p2s.c
@@ -26,7 +26,7 @@ void eraP2s(double p[3], double *theta, double *phi, double *r)
 **     eraC2s       p-vector to spherical
 **     eraPm        modulus of p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -39,7 +39,7 @@ void eraP2s(double p[3], double *theta, double *phi, double *r)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pap.c
+++ b/src/pap.c
@@ -37,12 +37,11 @@ double eraPap(double a[3], double b[3])
 **     eraPmp       p-vector minus p-vector
 **     eraPdp       scalar product of two p-vectors
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double am, au[3], bm, st, ct, xa, ya, za, eta[3], xi[3], a2b[3], pa;
-
 
 /* Modulus and direction of the a vector. */
    eraPn(a, &am, au);
@@ -87,7 +86,7 @@ double eraPap(double a[3], double b[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pas.c
+++ b/src/pas.c
@@ -26,12 +26,11 @@ double eraPas(double al, double ap, double bl, double bp)
 **
 **  2) Zero is returned if the two points are coincident.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double dl, x, y, pa;
-
 
    dl = bl - al;
    y = sin(dl) * cos(bp);
@@ -44,7 +43,7 @@ double eraPas(double al, double ap, double bl, double bp)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pb06.c
+++ b/src/pb06.c
@@ -63,12 +63,11 @@ void eraPb06(double date1, double date2,
 **     eraPmat06    PB matrix, IAU 2006
 **     eraRz        rotate around Z-axis
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double r[3][3], r31, r32;
-
 
 /* Precession matrix via Fukushima-Williams angles. */
    eraPmat06(date1, date2, r);
@@ -92,7 +91,7 @@ void eraPb06(double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pdp.c
+++ b/src/pdp.c
@@ -15,12 +15,11 @@ double eraPdp(double a[3], double b[3])
 **  Returned (function value):
 **            double        a . b
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double w;
-
 
    w  = a[0] * b[0]
       + a[1] * b[1]
@@ -32,7 +31,7 @@ double eraPdp(double a[3], double b[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pfw06.c
+++ b/src/pfw06.c
@@ -73,12 +73,11 @@ void eraPfw06(double date1, double date2,
 **  Called:
 **     eraObl06     mean obliquity, IAU 2006
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double t;
-
 
 /* Interval between fundamental date J2000.0 and given date (JC). */
    t = ((date1 - ERFA_DJ00) + date2) / ERFA_DJC;
@@ -113,7 +112,7 @@ void eraPfw06(double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/plan94.c
+++ b/src/plan94.c
@@ -157,7 +157,7 @@ int eraPlan94(double date1, double date2, int np, double pv[2][3])
 **              Chapront-Touze, M., Francou, G., and Laskar, J.,
 **              Astron. Astrophys. 282, 663 (1994).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -462,7 +462,7 @@ int eraPlan94(double date1, double date2, int np, double pv[2][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pm.c
+++ b/src/pm.c
@@ -14,7 +14,7 @@ double eraPm(double p[3])
 **  Returned (function value):
 **            double        modulus
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -24,7 +24,7 @@ double eraPm(double p[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pmat00.c
+++ b/src/pmat00.c
@@ -50,12 +50,11 @@ void eraPmat00(double date1, double date2, double rbp[3][3])
 **     24th General Assembly, Manchester, UK.  Resolutions B1.3, B1.6.
 **     (2000)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double rb[3][3], rp[3][3];
-
 
 /* Obtain the required matrix (discarding others). */
    eraBp00(date1, date2, rb, rp, rbp);
@@ -66,7 +65,7 @@ void eraPmat00(double date1, double date2, double rbp[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pmat06.c
+++ b/src/pmat06.c
@@ -51,12 +51,11 @@ void eraPmat06(double date1, double date2, double rbp[3][3])
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double gamb, phib, psib, epsa;
-
 
 /* Bias-precession Fukushima-Williams angles. */
    eraPfw06(date1, date2, &gamb, &phib, &psib, &epsa);
@@ -70,7 +69,7 @@ void eraPmat06(double date1, double date2, double rbp[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pmat76.c
+++ b/src/pmat76.c
@@ -66,12 +66,11 @@ void eraPmat76(double date1, double date2, double rmatp[3][3])
 **
 **     Kaplan,G.H., 1981. USNO circular no. 163, pA2.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double zeta, z, theta, wmat[3][3];
-
 
 /* Precession Euler angles, J2000.0 to specified date. */
    eraPrec76(ERFA_DJ00, 0.0, date1, date2, &zeta, &z, &theta);
@@ -89,7 +88,7 @@ void eraPmat76(double date1, double date2, double rmatp[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pmp.c
+++ b/src/pmp.c
@@ -19,7 +19,7 @@ void eraPmp(double a[3], double b[3], double amb[3])
 **     It is permissible to re-use the same array for any of the
 **     arguments.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -33,7 +33,7 @@ void eraPmp(double a[3], double b[3], double amb[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pmpx.c
+++ b/src/pmpx.c
@@ -46,7 +46,7 @@ void eraPmpx(double rc, double dc, double pr, double pd,
 **     eraPdp       scalar product of two p-vectors
 **     eraPn        decompose p-vector into modulus and direction
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -58,7 +58,6 @@ void eraPmpx(double rc, double dc, double pr, double pd,
 
    int i;
    double sr, cr, sd, cd, x, y, z, p[3], dt, pxr, w, pdz, pm[3];
-
 
 /* Spherical coordinates to unit vector (and useful functions). */
    sr = sin(rc);
@@ -92,7 +91,7 @@ void eraPmpx(double rc, double dc, double pr, double pd,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pmsafe.c
+++ b/src/pmsafe.c
@@ -105,7 +105,7 @@ int eraPmsafe(double ra1, double dec1, double pmr1, double pmd1,
 **     eraSeps      angle between two points
 **     eraStarpm    update star catalog data for space motion
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -118,7 +118,6 @@ int eraPmsafe(double ra1, double dec1, double pmr1, double pmd1,
 
    int jpx, j;
    double pm, px1a;
-
 
 /* Proper motion in one year (radians). */
    pm = eraSeps(ra1, dec1, ra1+pmr1, dec1+pmd1);
@@ -145,7 +144,7 @@ int eraPmsafe(double ra1, double dec1, double pmr1, double pmd1,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pn.c
+++ b/src/pn.c
@@ -28,12 +28,11 @@ void eraPn(double p[3], double *r, double u[3])
 **     eraZp        zero p-vector
 **     eraSxp       multiply p-vector by scalar
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double w;
-
 
 /* Obtain the modulus and test for zero. */
    w = eraPm(p);
@@ -57,7 +56,7 @@ void eraPn(double p[3], double *r, double u[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pn00.c
+++ b/src/pn00.c
@@ -95,12 +95,11 @@ void eraPn00(double date1, double date2, double dpsi, double deps,
 **     n.b. The celestial ephemeris origin (CEO) was renamed "celestial
 **          intermediate origin" (CIO) by IAU 2006 Resolution 2.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double dpsipr, depspr, rbpw[3][3], rnw[3][3];
-
 
 /* IAU 2000 precession-rate adjustments. */
    eraPr00(date1, date2, &dpsipr, &depspr);
@@ -125,7 +124,7 @@ void eraPn00(double date1, double date2, double dpsi, double deps,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pn00a.c
+++ b/src/pn00a.c
@@ -95,7 +95,7 @@ void eraPn00a(double date1, double date2,
 **     n.b. The celestial ephemeris origin (CEO) was renamed "celestial
 **          intermediate origin" (CIO) by IAU 2006 Resolution 2.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -111,7 +111,7 @@ void eraPn00a(double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pn00b.c
+++ b/src/pn00b.c
@@ -95,7 +95,7 @@ void eraPn00b(double date1, double date2,
 **     n.b. The celestial ephemeris origin (CEO) was renamed "celestial
 **          intermediate origin" (CIO) by IAU 2006 Resolution 2.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -111,7 +111,7 @@ void eraPn00b(double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pn06.c
+++ b/src/pn06.c
@@ -93,12 +93,11 @@ void eraPn06(double date1, double date2, double dpsi, double deps,
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double gamb, phib, psib, eps, r1[3][3], r2[3][3], rt[3][3];
-
 
 /* Bias-precession Fukushima-Williams angles of J2000.0 = frame bias. */
    eraPfw06(ERFA_DJM0, ERFA_DJM00, &gamb, &phib, &psib, &eps);
@@ -135,7 +134,7 @@ void eraPn06(double date1, double date2, double dpsi, double deps,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pn06a.c
+++ b/src/pn06a.c
@@ -85,7 +85,7 @@ void eraPn06a(double date1, double date2,
 **
 **     Capitaine, N. & Wallace, P.T., 2006, Astron.Astrophys. 450, 855
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -101,7 +101,7 @@ void eraPn06a(double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pnm00a.c
+++ b/src/pnm00a.c
@@ -53,12 +53,11 @@ void eraPnm00a(double date1, double date2, double rbpn[3][3])
 **     24th General Assembly, Manchester, UK.  Resolutions B1.3, B1.6.
 **     (2000)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double dpsi, deps, epsa, rb[3][3], rp[3][3], rbp[3][3], rn[3][3];
-
 
 /* Obtain the required matrix (discarding other results). */
    eraPn00a(date1, date2, &dpsi, &deps, &epsa, rb, rp, rbp, rn, rbpn);
@@ -69,7 +68,7 @@ void eraPnm00a(double date1, double date2, double rbpn[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pnm00b.c
+++ b/src/pnm00b.c
@@ -53,12 +53,11 @@ void eraPnm00b(double date1, double date2, double rbpn[3][3])
 **     24th General Assembly, Manchester, UK.  Resolutions B1.3, B1.6.
 **     (2000)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double dpsi, deps, epsa, rb[3][3], rp[3][3], rbp[3][3], rn[3][3];
-
 
 /* Obtain the required matrix (discarding other results). */
    eraPn00b(date1, date2, &dpsi, &deps, &epsa, rb, rp, rbp, rn, rbpn);
@@ -69,7 +68,7 @@ void eraPnm00b(double date1, double date2, double rbpn[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pnm06a.c
+++ b/src/pnm06a.c
@@ -50,12 +50,11 @@ void eraPnm06a(double date1, double date2, double rnpb[3][3])
 **
 **     Capitaine, N. & Wallace, P.T., 2006, Astron.Astrophys. 450, 855.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double gamb, phib, psib, epsa, dp, de;
-
 
 /* Fukushima-Williams angles for frame bias and precession. */
    eraPfw06(date1, date2, &gamb, &phib, &psib, &epsa);
@@ -72,7 +71,7 @@ void eraPnm06a(double date1, double date2, double rnpb[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pnm80.c
+++ b/src/pnm80.c
@@ -52,12 +52,11 @@ void eraPnm80(double date1, double date2, double rmatpn[3][3])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.3 (p145).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double rmatp[3][3], rmatn[3][3];
-
 
 /* Precession matrix, J2000.0 to date. */
    eraPmat76(date1, date2, rmatp);
@@ -74,7 +73,7 @@ void eraPnm80(double date1, double date2, double rmatpn[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pom00.c
+++ b/src/pom00.c
@@ -46,7 +46,7 @@ void eraPom00(double xp, double yp, double sp, double rpom[3][3])
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -63,7 +63,7 @@ void eraPom00(double xp, double yp, double sp, double rpom[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/ppp.c
+++ b/src/ppp.c
@@ -19,7 +19,7 @@ void eraPpp(double a[3], double b[3], double apb[3])
 **     It is permissible to re-use the same array for any of the
 **     arguments.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -33,7 +33,7 @@ void eraPpp(double a[3], double b[3], double apb[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/ppsp.c
+++ b/src/ppsp.c
@@ -23,12 +23,11 @@ void eraPpsp(double a[3], double s, double b[3], double apsb[3])
 **     eraSxp       multiply p-vector by scalar
 **     eraPpp       p-vector plus p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double sb[3];
-
 
 /* s*b. */
    eraSxp(s, b, sb);
@@ -42,7 +41,7 @@ void eraPpsp(double a[3], double s, double b[3], double apsb[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pr00.c
+++ b/src/pr00.c
@@ -66,7 +66,7 @@ void eraPr00(double date1, double date2, double *dpsipr, double *depspr)
 **     Wallace, P.T., "Software for Implementing the IAU 2000
 **     Resolutions", in IERS Workshop 5.1 (2002).
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -75,7 +75,6 @@ void eraPr00(double date1, double date2, double *dpsipr, double *depspr)
 /* Precession and obliquity corrections (radians per century) */
    static const double PRECOR = -0.29965 * ERFA_DAS2R,
                        OBLCOR = -0.02524 * ERFA_DAS2R;
-
 
 /* Interval between fundamental epoch J2000.0 and given date (JC). */
    t = ((date1 - ERFA_DJ00) + date2) / ERFA_DJC;
@@ -90,7 +89,7 @@ void eraPr00(double date1, double date2, double *dpsipr, double *depspr)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/prec76.c
+++ b/src/prec76.c
@@ -66,12 +66,11 @@ void eraPrec76(double date01, double date02, double date11, double date12,
 **     Lieske, J.H., 1979, Astron.Astrophys. 73, 282, equations
 **     (6) & (7), p283.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double t0, t, tas2r, w;
-
 
 /* Interval between fundamental epoch J2000.0 and start date (JC). */
    t0 = ((date01 - ERFA_DJ00) + date02) / ERFA_DJC;
@@ -96,7 +95,7 @@ void eraPrec76(double date01, double date02, double date11, double date12,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pv2p.c
+++ b/src/pv2p.c
@@ -17,7 +17,7 @@ void eraPv2p(double pv[2][3], double p[3])
 **  Called:
 **     eraCp        copy p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -29,7 +29,7 @@ void eraPv2p(double pv[2][3], double p[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pv2s.c
+++ b/src/pv2s.c
@@ -34,12 +34,11 @@ void eraPv2s(double pv[2][3],
 **  2) If the position is a pole, theta, td and pd are indeterminate.
 **     In such cases zeroes are returned for all three.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double x, y, z, xd, yd, zd, rxy2, rxy, r2, rtrue, rw, xyp;
-
 
 /* Components of position/velocity vector. */
    x  = pv[0][0];
@@ -92,7 +91,7 @@ void eraPv2s(double pv[2][3],
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pvdpv.c
+++ b/src/pvdpv.c
@@ -25,12 +25,11 @@ void eraPvdpv(double a[2][3], double b[2][3], double adb[2])
 **  Called:
 **     eraPdp       scalar product of two p-vectors
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double adbd, addb;
-
 
 /* a . b = constant part of result. */
    adb[0] = eraPdp(a[0], b[0]);
@@ -50,7 +49,7 @@ void eraPvdpv(double a[2][3], double b[2][3], double adb[2])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pvm.c
+++ b/src/pvm.c
@@ -18,7 +18,7 @@ void eraPvm(double pv[2][3], double *r, double *s)
 **  Called:
 **     eraPm        modulus of p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -34,7 +34,7 @@ void eraPvm(double pv[2][3], double *r, double *s)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pvmpv.c
+++ b/src/pvmpv.c
@@ -22,7 +22,7 @@ void eraPvmpv(double a[2][3], double b[2][3], double amb[2][3])
 **  Called:
 **     eraPmp       p-vector minus p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -35,7 +35,7 @@ void eraPvmpv(double a[2][3], double b[2][3], double amb[2][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pvppv.c
+++ b/src/pvppv.c
@@ -22,7 +22,7 @@ void eraPvppv(double a[2][3], double b[2][3], double apb[2][3])
 **  Called:
 **     eraPpp       p-vector plus p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -35,7 +35,7 @@ void eraPvppv(double a[2][3], double b[2][3], double apb[2][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pvstar.c
+++ b/src/pvstar.c
@@ -93,13 +93,12 @@ int eraPvstar(double pv[2][3], double *ra, double *dec,
 **
 **     Stumpff, P., 1985, Astron.Astrophys. 144, 232-240.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double r, x[3], vr, ur[3], vt, ut[3], bett, betr, d, w, del,
           usr[3], ust[3], a, rad, decd, rd;
-
 
 /* Isolate the radial component of the velocity (AU/day, inertial). */
    eraPn(pv[0], &r, x);
@@ -155,7 +154,7 @@ int eraPvstar(double pv[2][3], double *ra, double *dec,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pvtob.c
+++ b/src/pvtob.c
@@ -61,7 +61,7 @@ void eraPvtob(double elong, double phi, double hm,
 **     eraPom00     polar motion matrix
 **     eraTrxp      product of transpose of r-matrix and p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -69,7 +69,6 @@ void eraPvtob(double elong, double phi, double hm,
    const double OM = 1.00273781191135448 * ERFA_D2PI / ERFA_DAYSEC;
 
    double xyzm[3], rpm[3][3], xyz[3], x, y, z, s, c;
-
 
 /* Geodetic to geocentric transformation (ERFA_WGS84). */
    (void) eraGd2gc(1, elong, phi, hm, xyzm);
@@ -101,7 +100,7 @@ void eraPvtob(double elong, double phi, double hm,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pvu.c
+++ b/src/pvu.c
@@ -28,7 +28,7 @@ void eraPvu(double dt, double pv[2][3], double upv[2][3])
 **     eraPpsp      p-vector plus scaled p-vector
 **     eraCp        copy p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -41,7 +41,7 @@ void eraPvu(double dt, double pv[2][3], double upv[2][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pvup.c
+++ b/src/pvup.c
@@ -22,7 +22,7 @@ void eraPvup(double dt, double pv[2][3], double p[3])
 **
 **  2) The time units of dt must match those of the velocity.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -36,7 +36,7 @@ void eraPvup(double dt, double pv[2][3], double p[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pvxpv.c
+++ b/src/pvxpv.c
@@ -30,12 +30,11 @@ void eraPvxpv(double a[2][3], double b[2][3], double axb[2][3])
 **     eraPxp       vector product of two p-vectors
 **     eraPpp       p-vector plus p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double wa[2][3], wb[2][3], axbd[3], adxb[3];
-
 
 /* Make copies of the inputs. */
    eraCpv(a, wa);
@@ -55,7 +54,7 @@ void eraPvxpv(double a[2][3], double b[2][3], double axb[2][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/pxp.c
+++ b/src/pxp.c
@@ -19,12 +19,11 @@ void eraPxp(double a[3], double b[3], double axb[3])
 **     It is permissible to re-use the same array for any of the
 **     arguments.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double xa, ya, za, xb, yb, zb;
-
 
    xa = a[0];
    ya = a[1];
@@ -42,7 +41,7 @@ void eraPxp(double a[3], double b[3], double axb[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/refco.c
+++ b/src/refco.c
@@ -145,13 +145,12 @@ void eraRefco(double phpa, double tc, double rh, double wl,
 **
 **     Stone, Ronald C., P.A.S.P. 108, 1051-1058, 1996.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int optic;
    double p, t, r, w, ps, pw, tk, wlsq, gamma, beta;
-
 
 /* Decide whether optical/IR or radio case:  switch at 100 microns. */
    optic = ( wl <= 100.0 );
@@ -201,7 +200,7 @@ void eraRefco(double phpa, double tc, double rh, double wl,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/rm2v.c
+++ b/src/rm2v.c
@@ -29,7 +29,7 @@ void eraRm2v(double r[3][3], double w[3])
 **  3) The reference frame rotates clockwise as seen looking along
 **     the rotation vector from the origin.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -40,7 +40,7 @@ void eraRm2v(double r[3][3], double w[3])
    y = r[2][0] - r[0][2];
    z = r[0][1] - r[1][0];
    s2 = sqrt(x*x + y*y + z*z);
-   if (s2 != 0) {
+   if (s2 > 0) {
       c2 = r[0][0] + r[1][1] + r[2][2] - 1.0;
       phi = atan2(s2, c2);
       f =  phi / s2;
@@ -59,7 +59,7 @@ void eraRm2v(double r[3][3], double w[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/rv2m.c
+++ b/src/rv2m.c
@@ -26,7 +26,7 @@ void eraRv2m(double w[3], double r[3][3])
 **  3) The reference frame rotates clockwise as seen looking along the
 **     rotation vector from the origin.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -43,7 +43,7 @@ void eraRv2m(double w[3], double r[3][3])
    f = 1.0 - c;
 
 /* Euler axis (direction of rotation vector), perhaps null. */
-   if (phi != 0.0) {
+   if (phi > 0.0) {
        x /= phi;
        y /= phi;
        z /= phi;
@@ -66,7 +66,7 @@ void eraRv2m(double w[3], double r[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/rx.c
+++ b/src/rx.c
@@ -28,12 +28,11 @@ void eraRx(double phi, double r[3][3])
 **         (                               )
 **         (  0   - sin(phi)   + cos(phi)  )
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double s, c, a10, a11, a12, a20, a21, a22;
-
 
    s = sin(phi);
    c = cos(phi);
@@ -58,7 +57,7 @@ void eraRx(double phi, double r[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/rxp.c
+++ b/src/rxp.c
@@ -21,13 +21,12 @@ void eraRxp(double r[3][3], double p[3], double rp[3])
 **  Called:
 **     eraCp        copy p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double w, wrp[3];
    int i, j;
-
 
 /* Matrix r * vector p. */
    for (j = 0; j < 3; j++) {
@@ -47,7 +46,7 @@ void eraRxp(double r[3][3], double p[3], double rp[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/rxpv.c
+++ b/src/rxpv.c
@@ -21,7 +21,7 @@ void eraRxpv(double r[3][3], double pv[2][3], double rpv[2][3])
 **  Called:
 **     eraRxp       product of r-matrix and p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -34,7 +34,7 @@ void eraRxpv(double r[3][3], double pv[2][3], double rpv[2][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/rxr.c
+++ b/src/rxr.c
@@ -22,13 +22,12 @@ void eraRxr(double a[3][3], double b[3][3], double atb[3][3])
 **  Called:
 **     eraCr        copy r-matrix
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int i, j, k;
    double w, wm[3][3];
-
 
    for (i = 0; i < 3; i++) {
       for (j = 0; j < 3; j++) {
@@ -47,7 +46,7 @@ void eraRxr(double a[3][3], double b[3][3], double atb[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/ry.c
+++ b/src/ry.c
@@ -28,12 +28,11 @@ void eraRy(double theta, double r[3][3])
 **         (                                        )
 **         (  + sin(theta)     0      + cos(theta)  )
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double s, c, a00, a01, a02, a20, a21, a22;
-
 
    s = sin(theta);
    c = cos(theta);
@@ -58,7 +57,7 @@ void eraRy(double theta, double r[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/rz.c
+++ b/src/rz.c
@@ -28,12 +28,11 @@ void eraRz(double psi, double r[3][3])
 **         (                                 )
 **         (       0            0         1  )
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double s, c, a00, a01, a02, a10, a11, a12;
-
 
    s = sin(psi);
    c = cos(psi);
@@ -58,7 +57,7 @@ void eraRz(double psi, double r[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/s00.c
+++ b/src/s00.c
@@ -76,7 +76,7 @@ double eraS00(double date1, double date2, double x, double y)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -319,7 +319,7 @@ double eraS00(double date1, double date2, double x, double y)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/s00a.c
+++ b/src/s00a.c
@@ -69,12 +69,11 @@ double eraS00a(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double rbpn[3][3], x, y, s;
-
 
 /* Bias-precession-nutation-matrix, IAU 2000A. */
    eraPnm00a(date1, date2, rbpn);
@@ -91,7 +90,7 @@ double eraS00a(double date1, double date2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/s00b.c
+++ b/src/s00b.c
@@ -69,12 +69,11 @@ double eraS00b(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double rbpn[3][3], x, y, s;
-
 
 /* Bias-precession-nutation-matrix, IAU 2000B. */
    eraPnm00b(date1, date2, rbpn);
@@ -91,7 +90,7 @@ double eraS00b(double date1, double date2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/s06.c
+++ b/src/s06.c
@@ -73,7 +73,7 @@ double eraS06(double date1, double date2, double x, double y)
 **     McCarthy, D.D., Petit, G. (eds.) 2004, IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -316,7 +316,7 @@ double eraS06(double date1, double date2, double x, double y)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/s06a.c
+++ b/src/s06a.c
@@ -71,12 +71,11 @@ double eraS06a(double date1, double date2)
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double rnpb[3][3], x, y, s;
-
 
 /* Bias-precession-nutation-matrix, IAU 20006/2000A. */
    eraPnm06a(date1, date2, rnpb);
@@ -93,7 +92,7 @@ double eraS06a(double date1, double date2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/s2c.c
+++ b/src/s2c.c
@@ -15,12 +15,11 @@ void eraS2c(double theta, double phi, double c[3])
 **  Returned:
 **     c        double[3]    direction cosines
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double cp;
-
 
    cp = cos(phi);
    c[0] = cos(theta) * cp;
@@ -33,7 +32,7 @@ void eraS2c(double theta, double phi, double c[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/s2p.c
+++ b/src/s2p.c
@@ -20,12 +20,11 @@ void eraS2p(double theta, double phi, double r, double p[3])
 **     eraS2c       spherical coordinates to unit vector
 **     eraSxp       multiply p-vector by scalar
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double u[3];
-
 
    eraS2c(theta, phi, u);
    eraSxp(r, u, p);
@@ -36,7 +35,7 @@ void eraS2p(double theta, double phi, double r, double p[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/s2pv.c
+++ b/src/s2pv.c
@@ -21,12 +21,11 @@ void eraS2pv(double theta, double phi, double r,
 **  Returned:
 **     pv       double[2][3]    pv-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double st, ct, sp, cp, rcp, x, y, rpd, w;
-
 
    st = sin(theta);
    ct = cos(theta);
@@ -51,7 +50,7 @@ void eraS2pv(double theta, double phi, double r,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/s2xpv.c
+++ b/src/s2xpv.c
@@ -22,7 +22,7 @@ void eraS2xpv(double s1, double s2, double pv[2][3], double spv[2][3])
 **  Called:
 **     eraSxp       multiply p-vector by scalar
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -35,7 +35,7 @@ void eraS2xpv(double s1, double s2, double pv[2][3], double spv[2][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/sepp.c
+++ b/src/sepp.c
@@ -30,12 +30,11 @@ double eraSepp(double a[3], double b[3])
 **     eraPm        modulus of p-vector
 **     eraPdp       scalar product of two p-vectors
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double axb[3], ss, cs, s;
-
 
 /* Sine of angle between the vectors, multiplied by the two moduli. */
    eraPxp(a, b, axb);
@@ -53,7 +52,7 @@ double eraSepp(double a[3], double b[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/seps.c
+++ b/src/seps.c
@@ -21,12 +21,11 @@ double eraSeps(double al, double ap, double bl, double bp)
 **     eraS2c       spherical coordinates to unit vector
 **     eraSepp      angular separation between two p-vectors
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double ac[3], bc[3], s;
-
 
 /* Spherical to Cartesian. */
    eraS2c(al, ap, ac);
@@ -41,7 +40,7 @@ double eraSeps(double al, double ap, double bl, double bp)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/sp00.c
+++ b/src/sp00.c
@@ -47,12 +47,11 @@ double eraSp00(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double t, sp;
-
 
 /* Interval between fundamental epoch J2000.0 and current date (JC). */
    t = ((date1 - ERFA_DJ00) + date2) / ERFA_DJC;
@@ -66,7 +65,7 @@ double eraSp00(double date1, double date2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/starpm.c
+++ b/src/starpm.c
@@ -106,14 +106,13 @@ int eraStarpm(double ra1, double dec1,
 **     eraPdp       scalar product of two p-vectors
 **     eraPvstar    space motion pv-vector to star catalog data
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double pv1[2][3], tl1, dt, pv[2][3], r2, rdv, v2, c2mv2, tl2,
           pv2[2][3];
    int j1, j2, j;
-
 
 /* RA,Dec etc. at the "before" epoch to space motion pv-vector. */
    j1 = eraStarpv(ra1, dec1, pmr1, pmd1, px1, rv1, pv1);
@@ -153,7 +152,7 @@ int eraStarpm(double ra1, double dec1,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/starpv.c
+++ b/src/starpv.c
@@ -113,7 +113,7 @@ int eraStarpv(double ra, double dec,
 **
 **     Stumpff, P., 1985, Astron.Astrophys. 144, 232-240.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -133,7 +133,6 @@ int eraStarpv(double ra, double dec,
           d = 0.0, del = 0.0,       /* to prevent */
           odd = 0.0, oddel = 0.0,   /* compiler   */
           od = 0.0, odel = 0.0;     /* warnings   */
-
 
 /* Distance (AU). */
    if (px >= PXMIN) {
@@ -212,7 +211,7 @@ int eraStarpv(double ra, double dec,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/sxp.c
+++ b/src/sxp.c
@@ -18,7 +18,7 @@ void eraSxp(double s, double p[3], double sp[3])
 **  Note:
 **     It is permissible for p and sp to be the same array.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -32,7 +32,7 @@ void eraSxp(double s, double p[3], double sp[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/sxpv.c
+++ b/src/sxpv.c
@@ -21,7 +21,7 @@ void eraSxpv(double s, double pv[2][3], double spv[2][3])
 **  Called:
 **     eraS2xpv     multiply pv-vector by two scalars
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -33,7 +33,7 @@ void eraSxpv(double s, double pv[2][3], double spv[2][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/t_erfa_c.c
+++ b/src/t_erfa_c.c
@@ -17,7 +17,7 @@ static int verbose = 0;
 **
 **  All messages go to stdout.
 **
-**  This revision:  2013 November 7
+**  This revision:  2015 January 30
 **
 */
 
@@ -2902,7 +2902,7 @@ static void t_dat(int *status)
 **
 **  Called:  eraDat, vvd, viv
 **
-**  This revision:  2013 August 7
+**  This revision:  2015 January 30
 */
 {
    int j;
@@ -2918,6 +2918,11 @@ static void t_dat(int *status)
 
    vvd(deltat, 33.0, 0.0, "eraDat", "d2", status);
    viv(j, 0, "eraDat", "j2", status);
+
+   j = eraDat(2015, 9, 1, 0.0, &deltat);
+
+   vvd(deltat, 36.0, 0.0, "eraDat", "d3", status);
+   viv(j, 0, "eraDat", "j3", status);
 
 }
 
@@ -3900,6 +3905,32 @@ static void t_fw2xy(int *status)
 
 }
 
+static void t_g2icrs(int *status)
+/*
+**  - - - - - - - - -
+**   t _ g 2 i c r s
+**  - - - - - - - - -
+**
+**  Test eraG2icrs function.
+**
+**  Returned:
+**     status    int         FALSE = success, TRUE = fail
+**
+**  Called:  eraG2icrs, vvd
+**
+**  This revision:  2015 January 30
+*/
+{
+   double dl, db, dr, dd;
+
+
+   dl =  5.5850536063818546461558105;
+   db = -0.7853981633974483096156608;
+   eraG2icrs (dl, db, &dr, &dd);
+   vvd(dr,  5.9338074302227188048671, 1e-14, "eraG2icrs", "R", status);
+   vvd(dd, -1.1784870613579944551541, 1e-14, "eraG2icrs", "D", status);
+ }
+
 static void t_gc2gd(int *status)
 /*
 **  - - - - - - - -
@@ -4269,6 +4300,31 @@ static void t_gst94(int *status)
    vvd(theta, 1.754166136020645203, 1e-12, "eraGst94", "", status);
 
 }
+
+static void t_icrs2g(int *status)
+/*
+**  - - - - - - - - -
+**   t _ i c r s 2 g
+**  - - - - - - - - -
+**
+**  Test eraIcrs2g function.
+**
+**  Returned:
+**     status    int         FALSE = success, TRUE = fail
+**
+**  Called:  eraIcrs2g, vvd
+**
+**  This revision:  2015 January 30
+*/
+{
+   double dr, dd, dl, db;
+
+   dr =  5.9338074302227188048671087;
+   dd = -1.1784870613579944551540570;
+   eraIcrs2g (dr, dd, &dl, &db);
+   vvd(dl,  5.5850536063818546461558, 1e-14, "eraIcrs2g", "L", status);
+   vvd(db, -0.7853981633974483096157, 1e-14, "eraIcrs2g", "B", status);
+ }
 
 static void t_h2fk5(int *status)
 /*
@@ -9111,6 +9167,7 @@ int main(int argc, char *argv[])
    t_fk5hz(&status);
    t_fw2m(&status);
    t_fw2xy(&status);
+   t_g2icrs(&status);
    t_gc2gd(&status);
    t_gc2gde(&status);
    t_gd2gc(&status);
@@ -9125,6 +9182,7 @@ int main(int argc, char *argv[])
    t_gst94(&status);
    t_h2fk5(&status);
    t_hfk5z(&status);
+   t_icrs2g(&status);
    t_ir(&status);
    t_jd2cal(&status);
    t_jdcalf(&status);
@@ -9250,7 +9308,7 @@ int main(int argc, char *argv[])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/taitt.c
+++ b/src/taitt.c
@@ -33,14 +33,13 @@ int eraTaitt(double tai1, double tai2, double *tt1, double *tt2)
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
 
 /* TT minus TAI (days). */
    static const double dtat = ERFA_TTMTAI/ERFA_DAYSEC;
-
 
 /* Result, safeguarding precision. */
    if ( tai1 > tai2 ) {
@@ -58,7 +57,7 @@ int eraTaitt(double tai1, double tai2, double *tt1, double *tt2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/taiut1.c
+++ b/src/taiut1.c
@@ -35,12 +35,11 @@ int eraTaiut1(double tai1, double tai2, double dta,
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double dtad;
-
 
 /* Result, safeguarding precision. */
    dtad = dta / ERFA_DAYSEC;
@@ -59,7 +58,7 @@ int eraTaiut1(double tai1, double tai2, double dta,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/taiutc.c
+++ b/src/taiutc.c
@@ -56,14 +56,13 @@ int eraTaiutc(double tai1, double tai2, double *utc1, double *utc2)
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int big1;
    int i, j;
    double a1, a2, u1, u2, g1, g2;
-
 
 /* Put the two parts of the TAI into big-first order. */
    big1 = ( tai1 >= tai2 );
@@ -107,7 +106,7 @@ int eraTaiutc(double tai1, double tai2, double *utc1, double *utc2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/tcbtdb.c
+++ b/src/tcbtdb.c
@@ -47,7 +47,7 @@ int eraTcbtdb(double tcb1, double tcb2, double *tdb1, double *tdb2)
 **
 **     IAU 2006 Resolution B3
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -60,7 +60,6 @@ int eraTcbtdb(double tcb1, double tcb2, double *tdb1, double *tdb2)
    static const double tdb0 = ERFA_TDB0/ERFA_DAYSEC;
 
    double d;
-
 
 /* Result, safeguarding precision. */
    if ( tcb1 > tcb2 ) {
@@ -80,7 +79,7 @@ int eraTcbtdb(double tcb1, double tcb2, double *tdb1, double *tdb2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/tcgtt.c
+++ b/src/tcgtt.c
@@ -32,14 +32,13 @@ int eraTcgtt(double tcg1, double tcg2, double *tt1, double *tt2)
 **
 **     IAU 2000 Resolution B1.9
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
 
 /* 1977 Jan 1 00:00:32.184 TT, as MJD */
    static const double t77t = ERFA_DJM77 + ERFA_TTMTAI/ERFA_DAYSEC;
-
 
 /* Result, safeguarding precision. */
    if ( tcg1 > tcg2 ) {
@@ -57,7 +56,7 @@ int eraTcgtt(double tcg1, double tcg2, double *tt1, double *tt2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/tdbtcb.c
+++ b/src/tdbtcb.c
@@ -47,7 +47,7 @@ int eraTdbtcb(double tdb1, double tdb2, double *tcb1, double *tcb2)
 **
 **     IAU 2006 Resolution B3
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -63,7 +63,6 @@ int eraTdbtcb(double tdb1, double tdb2, double *tcb1, double *tcb2)
    static const double elbb = ERFA_ELB/(1.0-ERFA_ELB);
 
    double d, f;
-
 
 /* Result, preserving date format but safeguarding precision. */
    if ( tdb1 > tdb2 ) {
@@ -85,7 +84,7 @@ int eraTdbtcb(double tdb1, double tdb2, double *tcb1, double *tcb2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/tdbtt.c
+++ b/src/tdbtt.c
@@ -45,12 +45,11 @@ int eraTdbtt(double tdb1, double tdb2, double dtr,
 **
 **     IAU 2006 Resolution 3
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double dtrd;
-
 
 /* Result, safeguarding precision. */
    dtrd = dtr / ERFA_DAYSEC;
@@ -69,7 +68,7 @@ int eraTdbtt(double tdb1, double tdb2, double dtr,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/tf2a.c
+++ b/src/tf2a.c
@@ -34,7 +34,7 @@ int eraTf2a(char s, int ihour, int imin, double sec, double *rad)
 **  3)  If there are multiple errors, the status value reflects only the
 **      first, the smallest taking precedence.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -55,7 +55,7 @@ int eraTf2a(char s, int ihour, int imin, double sec, double *rad)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/tf2d.c
+++ b/src/tf2d.c
@@ -34,7 +34,7 @@ int eraTf2d(char s, int ihour, int imin, double sec, double *days)
 **  3)  If there are multiple errors, the status value reflects only the
 **      first, the smallest taking precedence.
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -55,7 +55,7 @@ int eraTf2d(char s, int ihour, int imin, double sec, double *days)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/tr.c
+++ b/src/tr.c
@@ -20,13 +20,12 @@ void eraTr(double r[3][3], double rt[3][3])
 **  Called:
 **     eraCr        copy r-matrix
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double wm[3][3];
    int i, j;
-
 
    for (i = 0; i < 3; i++) {
       for (j = 0; j < 3; j++) {
@@ -41,7 +40,7 @@ void eraTr(double r[3][3], double rt[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/trxp.c
+++ b/src/trxp.c
@@ -22,12 +22,11 @@ void eraTrxp(double r[3][3], double p[3], double trp[3])
 **     eraTr        transpose r-matrix
 **     eraRxp       product of r-matrix and p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double tr[3][3];
-
 
 /* Transpose of matrix r. */
    eraTr(r, tr);
@@ -41,7 +40,7 @@ void eraTrxp(double r[3][3], double p[3], double trp[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/trxpv.c
+++ b/src/trxpv.c
@@ -22,12 +22,11 @@ void eraTrxpv(double r[3][3], double pv[2][3], double trpv[2][3])
 **     eraTr        transpose r-matrix
 **     eraRxpv      product of r-matrix and pv-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double tr[3][3];
-
 
 /* Transpose of matrix r. */
    eraTr(r, tr);
@@ -41,7 +40,7 @@ void eraTrxpv(double r[3][3], double pv[2][3], double trpv[2][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/tttai.c
+++ b/src/tttai.c
@@ -33,14 +33,13 @@ int eraTttai(double tt1, double tt2, double *tai1, double *tai2)
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
 
 /* TT minus TAI (days). */
    static const double dtat = ERFA_TTMTAI/ERFA_DAYSEC;
-
 
 /* Result, safeguarding precision. */
    if ( tt1 > tt2 ) {
@@ -58,7 +57,7 @@ int eraTttai(double tt1, double tt2, double *tai1, double *tai2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/tttcg.c
+++ b/src/tttcg.c
@@ -32,7 +32,7 @@ int eraTttcg(double tt1, double tt2, double *tcg1, double *tcg2)
 **
 **     IAU 2000 Resolution B1.9
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -42,7 +42,6 @@ int eraTttcg(double tt1, double tt2, double *tcg1, double *tcg2)
 
 /* TT to TCG rate */
    static const double elgg = ERFA_ELG/(1.0-ERFA_ELG);
-
 
 /* Result, safeguarding precision. */
    if ( tt1 > tt2 ) {
@@ -60,7 +59,7 @@ int eraTttcg(double tt1, double tt2, double *tcg1, double *tcg2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/tttdb.c
+++ b/src/tttdb.c
@@ -45,12 +45,11 @@ int eraTttdb(double tt1, double tt2, double dtr,
 **
 **     IAU 2006 Resolution 3
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double dtrd;
-
 
 /* Result, safeguarding precision. */
    dtrd = dtr / ERFA_DAYSEC;
@@ -69,7 +68,7 @@ int eraTttdb(double tt1, double tt2, double dtr,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/ttut1.c
+++ b/src/ttut1.c
@@ -34,12 +34,11 @@ int eraTtut1(double tt1, double tt2, double dt,
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double dtd;
-
 
 /* Result, safeguarding precision. */
    dtd = dt / ERFA_DAYSEC;
@@ -58,7 +57,7 @@ int eraTtut1(double tt1, double tt2, double dt,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/ut1tai.c
+++ b/src/ut1tai.c
@@ -35,12 +35,11 @@ int eraUt1tai(double ut11, double ut12, double dta,
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double dtad;
-
 
 /* Result, safeguarding precision. */
    dtad = dta / ERFA_DAYSEC;
@@ -59,7 +58,7 @@ int eraUt1tai(double ut11, double ut12, double dta,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/ut1tt.c
+++ b/src/ut1tt.c
@@ -34,12 +34,11 @@ int eraUt1tt(double ut11, double ut12, double dt,
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double dtd;
-
 
 /* Result, safeguarding precision. */
    dtd = dt / ERFA_DAYSEC;
@@ -58,7 +57,7 @@ int eraUt1tt(double ut11, double ut12, double dt,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/ut1utc.c
+++ b/src/ut1utc.c
@@ -62,14 +62,13 @@ int eraUt1utc(double ut11, double ut12, double dut1,
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int big1;
    int i, iy, im, id, js;
    double duts, u1, u2, d1, dats1, d2, fd, dats2, ddats, us1, us2, du;
-
 
 /* UT1-UTC in seconds. */
    duts = dut1;
@@ -141,7 +140,7 @@ int eraUt1utc(double ut11, double ut12, double dut1,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/utctai.c
+++ b/src/utctai.c
@@ -58,14 +58,13 @@ int eraUtctai(double utc1, double utc2, double *tai1, double *tai2)
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int big1;
    int iy, im, id, j, iyt, imt, idt;
    double u1, u2, fd, dat0, dat12, w, dat24, dlod, dleap, z1, z2, a2;
-
 
 /* Put the two parts of the UTC into big-first order. */
    big1 = ( utc1 >= utc2 );
@@ -125,7 +124,7 @@ int eraUtctai(double utc1, double utc2, double *tai1, double *tai2)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/utcut1.c
+++ b/src/utcut1.c
@@ -63,13 +63,12 @@ int eraUtcut1(double utc1, double utc2, double dut1,
 **     eraUtctai    UTC to TAI
 **     eraTaiut1    TAI to UT1
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    int iy, im, id, js, jw;
    double w, dat, dta, tai1, tai2;
-
 
 /* Look up TAI-UTC. */
    if ( eraJd2cal(utc1, utc2, &iy, &im, &id, &w) ) return -1;
@@ -95,7 +94,7 @@ int eraUtcut1(double utc1, double utc2, double dut1,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/xy06.c
+++ b/src/xy06.c
@@ -85,7 +85,7 @@ void eraXy06(double date1, double date2, double *x, double *y)
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -2706,7 +2706,7 @@ void eraXy06(double date1, double date2, double *x, double *y)
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/xys00a.c
+++ b/src/xys00a.c
@@ -59,12 +59,11 @@ void eraXys00a(double date1, double date2,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double rbpn[3][3];
-
 
 /* Form the bias-precession-nutation matrix, IAU 2000A. */
    eraPnm00a(date1, date2, rbpn);
@@ -81,7 +80,7 @@ void eraXys00a(double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/xys00b.c
+++ b/src/xys00b.c
@@ -59,12 +59,11 @@ void eraXys00b(double date1, double date2,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double rbpn[3][3];
-
 
 /* Form the bias-precession-nutation matrix, IAU 2000A. */
    eraPnm00b(date1, date2, rbpn);
@@ -81,7 +80,7 @@ void eraXys00b(double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/xys06a.c
+++ b/src/xys06a.c
@@ -59,12 +59,11 @@ void eraXys06a(double date1, double date2,
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    double rbpn[3][3];
-
 
 /* Form the bias-precession-nutation matrix, IAU 2006/2000A. */
    eraPnm06a(date1, date2, rbpn);
@@ -81,7 +80,7 @@ void eraXys06a(double date1, double date2,
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/zp.c
+++ b/src/zp.c
@@ -11,7 +11,7 @@ void eraZp(double p[3])
 **  Returned:
 **     p        double[3]      p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -25,7 +25,7 @@ void eraZp(double p[3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/zpv.c
+++ b/src/zpv.c
@@ -14,7 +14,7 @@ void eraZpv(double pv[2][3])
 **  Called:
 **     eraZp        zero p-vector
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -27,7 +27,7 @@ void eraZpv(double pv[2][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International

--- a/src/zr.c
+++ b/src/zr.c
@@ -11,7 +11,7 @@ void eraZr(double r[3][3])
 **  Returned:
 **     r        double[3][3]    r-matrix
 **
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
@@ -31,7 +31,7 @@ void eraZr(double r[3][3])
 /*----------------------------------------------------------------------
 **  
 **  
-**  Copyright (C) 2013-2014, NumFOCUS Foundation.
+**  Copyright (C) 2013-2015, NumFOCUS Foundation.
 **  All rights reserved.
 **  
 **  This library is derived, with permission, from the International


### PR DESCRIPTION
Syncs up ERFA with release 2015-02-09 of SOFA.

I have attempted to retain the local patch to `dat.c`.

The change looks larger than it really is because of the change in copyright date.

SOFA release notes:

- [New Material] 2 routines, iauG2icrs and iauIcrs2g, have been released for the new Galactic Coordinates section. They allow transformations to be made between the 1958 IAU galactic coordinate system and the ICRS.
- [Update/Change] Updated iauDat to account for the leap second at the end of June 2015.
- [Update/Change] Changes to iauC2ixys, iauGc2gde, iauRm2v and iauRv2m. There was a test for zero that could potentially cause compiler warnings. The test has been changed.
- [Update/Change] Changes to sofa.h. Addition of the new functions, removal of duplicate functions. All functions are listed in the categories that are given on the website and in the manual.
- [Update/Change] Update to t_sofa_c.c to accommodate the new routines.