### PR TITLE
Improve accuracy of eraStarpv()

### DIFF
--- a/src/starpv.c
+++ b/src/starpv.c
@@ -180,7 +180,8 @@ int eraStarpv(double ra, double dec,
    betr = betsr;
    for (i = 0; i < IMAX; i++) {
       d = 1.0 + betr;
-      del = sqrt(1.0 - betr*betr - bett*bett) - 1.0;
+      del = -(betr*betr + bett*bett);
+      del /= sqrt(1.0 + del) + 1.0;
       betr = d * betsr + del;
       bett = d * betst;
       if (i > 0) {

--- a/src/t_erfa_c.c
+++ b/src/t_erfa_c.c
@@ -3850,7 +3850,7 @@ static void t_fk52h(int *status)
        "eraFk52h", "dd5", status);
    vvd(pxh,  0.37921, 1e-14,
        "eraFk52h", "px", status);
-   vvd(rvh, -7.6000000940000254, 1e-11,
+   vvd(rvh, -7.6000000939851349, 1e-11,
        "eraFk52h", "rv", status);
 
 }


### PR DESCRIPTION
In the relativistic correction, the term
```
del = sqrt(1+x) - 1
```
is used with a rather small value of `x` (often 1e-8 or such). This gives inaccurate results because of the subtraction of 1 from a number very close to 1.

To improve this, the right term is extended by `sqrt(1+x)+1`, which gives
```
 del = x / (sqrt(1+x) + 1)
```
without a subtraction of two equally large numbers and therefore a better accuracy. This helps ~~on i386 FPU.~~ to get on all platform results that are as excellent as with the x87 FPU ;-)

The test is adjusted as well.

This will fix #33.