### PR TITLE
add void to make version-related functions not have prototype warnings

### DIFF
--- a/src/erfaextra.h
+++ b/src/erfaextra.h
@@ -20,35 +20,35 @@ extern "C" {
 ** as defined in configure.ac
 ** in string format
 */
-const char* eraVersion();
+const char* eraVersion(void);
 
 /* 
 ** Returns the package major version
 ** as defined in configure.ac
 ** as integer
 */
-int eraVersionMajor();
+int eraVersionMajor(void);
 
 /* 
 ** Returns the package minor version
 ** as defined in configure.ac
 ** as integer
 */
-int eraVersionMinor();
+int eraVersionMinor(void);
 
 /* 
 ** Returns the package micro version
 ** as defined in configure.ac
 ** as integer
 */
-int eraVersionMicro();
+int eraVersionMicro(void);
 
 /* 
 ** Returns the orresponding SOFA version
 ** as defined in configure.ac
 ** in string format
 */
-const char* eraSofaVersion();
+const char* eraSofaVersion(void);
 
 
 #ifdef __cplusplus

--- a/src/erfaversion.c
+++ b/src/erfaversion.c
@@ -12,27 +12,27 @@
 #endif /* HAVE_CONFIG_H */
 
 
-const char* eraVersion() {
+const char* eraVersion(void) {
   return PACKAGE_VERSION;
 }
 
 
-int eraVersionMajor() {
+int eraVersionMajor(void) {
   return PACKAGE_VERSION_MAJOR;
 }
 
 
-int eraVersionMinor() {
+int eraVersionMinor(void) {
   return PACKAGE_VERSION_MINOR;
 }
 
 
-int eraVersionMicro() {
+int eraVersionMicro(void) {
   return PACKAGE_VERSION_MICRO;
 }
 
 
-const char* eraSofaVersion() {
+const char* eraSofaVersion(void) {
   return SOFA_VERSION;
 }
 


### PR DESCRIPTION
This adjustment is the same as astropy/astropy#6249, which was prompted by @saimn's https://github.com/astropy/astropy/pull/6239#discussion_r122963518.  The underlying issue is that the various ``something eraVersion() {`` functions from #38 were creating compiler warnings like:
```
warning: function declaration isn’t a prototype [-Wstrict-prototypes] 
``` 
So this PR addresses that. 

@mhvk also suggested in astropy/astropy#6249 that we try to make sure the tests catch this in the future.  I'm not sure how to do this, though... When I look at the travis build logs I'm not seeing this warning at all (see e.g. https://travis-ci.org/liberfa/erfa).  @saimn, do you have any insight here? I would expect not `clang`, but we have a separate `gcc` build...

cc @sergiopasra as the author of #38 