### PR TITLE
Added a hook to eraDat to update the leap seconds.

### DIFF
--- a/src/dat.c
+++ b/src/dat.c
@@ -1,5 +1,14 @@
 #include "erfa.h"
 
+static eraLEAPSECOND *changes = 0;
+static int NDAT = 0;
+
+void eraUpdateLeapSeconds(eraLEAPSECOND *leapseconds, int count)
+{
+   changes = leapseconds;
+   NDAT = count;
+}
+
 int eraDat(int iy, int im, int id, double fd, double *deltat )
 /*
 **  - - - - - - -
@@ -144,10 +153,7 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
    enum { NERA1 = (int) (sizeof drift / sizeof (double) / 2) };
 
 /* Dates and Delta(AT)s */
-   static const struct {
-      int iyear, month;
-      double delat;
-   } changes[] = {
+   static const eraLEAPSECOND _changes[] = {
       { 1960,  1,  1.4178180 },
       { 1961,  1,  1.4228180 },
       { 1961,  8,  1.3728180 },
@@ -193,7 +199,13 @@ int eraDat(int iy, int im, int id, double fd, double *deltat )
    };
 
 /* Number of Delta(AT) changes */
-   enum { NDAT = (int) (sizeof changes / sizeof changes[0]) };
+   enum { _NDAT = (int) (sizeof _changes / sizeof _changes[0]) };
+   
+/* Initialise leap seconds if needed */
+   if ( NDAT == 0) {
+      NDAT = _NDAT;
+      changes = (eraLEAPSECOND *)_changes;
+   }
 
 /* Miscellaneous local variables */
    int j, i, m;

--- a/src/erfa.h
+++ b/src/erfa.h
@@ -337,6 +337,7 @@ int eraGd2gce(double a, double f,
 /* Astronomy/Timescales */
 int eraD2dtf(const char *scale, int ndp, double d1, double d2,
              int *iy, int *im, int *id, int ihmsf[4]);
+void eraUpdateLeapSeconds(eraLEAPSECOND *leapseconds, int count);
 int eraDat(int iy, int im, int id, double fd, double *deltat);
 double eraDtdb(double date1, double date2,
                double ut, double elong, double u, double v);

--- a/src/erfam.h
+++ b/src/erfam.h
@@ -41,6 +41,12 @@ typedef struct {
    double pv[2][3];   /* barycentric PV of the body (au, au/day) */
 } eraLDBODY;
 
+/* Leap second definition */
+typedef struct {
+   int iyear, month;
+   double delat;
+} eraLEAPSECOND;
+
 /* Pi */
 #define ERFA_DPI (3.141592653589793238462643)
 


### PR DESCRIPTION
DO NOT MERGE - Pull Request to stimulate discussions with respect to #43.

I have tried to keep the changes to SOFA/ERFA to a bare minimum. The PR intercepts the `changes` and `NDAT` parameters in `eraDat`, and provides a way to override them: `eraUpdateLeapSeconds`. Memory management and production of the appropriate `eraLEAPSECOND` array is left to the caller.

Note: the SOFA/ERFA test suite passes with these changes.