### PR TITLE
Add CFLAGS env variable with -Wstrict-prototypes in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: c
 
+env:
+  - CFLAGS="-Wall -Wstrict-prototypes"
+
 compiler:
   - clang
   - gcc


### PR DESCRIPTION
I have added a section in `.travis.yml` to pass compilation flags to the compilers. In this configuration the same flags apply to gcc and clang. If we need different flags, it would require a `matrix` entry in the file