### PR TITLE
Leap second access

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -30,9 +30,9 @@ tcgtt.c tdbtcb.c tdbtt.c tf2a.c tf2d.c tpors.c tporv.c tpsts.c \
 tpstv.c tpxes.c tpxev.c tr.c trxp.c trxpv.c tttai.c \
 tttcg.c tttdb.c ttut1.c ut1tai.c ut1tt.c ut1utc.c utctai.c utcut1.c \
 xy06.c xys00a.c xys00b.c xys06a.c zp.c zpv.c zr.c \
-erfaversion.c
+erfaversion.c erfadatextra.c
 
-include_HEADERS = erfa.h erfam.h erfaextra.h
+include_HEADERS = erfa.h erfam.h erfaextra.h erfadatextra.h
 
 ## Version info is in current : revision : age form
 ## A library supports interfaces from current downto current - age

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -44,8 +44,9 @@ liberfa_la_LDFLAGS = -version-info $(VI_ALL)
 
 
 ## Check program
-TESTS = t_erfa_c
-check_PROGRAMS = t_erfa_c
+TESTS = t_erfa_c t_erfa_c_extra
+check_PROGRAMS = t_erfa_c t_erfa_c_extra
 t_erfa_c_SOURCES = t_erfa_c.c
+t_erfa_c_extra_SOURCES = t_erfa_c_extra.c
 AM_CPPFLAGS = -I$(top_srcdir)
 LDADD = $(top_builddir)/src/liberfa.la

--- a/src/dat.c
+++ b/src/dat.c
@@ -1,5 +1,14 @@
 #include "erfa.h"
 
+static eraLEAPSECOND *changes = 0;
+static int NDAT = 0;
+
+void eraUpdateLeapSeconds(eraLEAPSECOND *leapseconds, int count)
+{
+   changes = leapseconds;
+   NDAT = count;
+}
+
 int eraDat(int iy, int im, int id, double fd, double *deltat)
 /*
 **  - - - - - - -
@@ -144,10 +153,7 @@ int eraDat(int iy, int im, int id, double fd, double *deltat)
    enum { NERA1 = (int) (sizeof drift / sizeof (double) / 2) };
 
 /* Dates and Delta(AT)s */
-   static const struct {
-      int iyear, month;
-      double delat;
-   } changes[] = {
+   static const eraLEAPSECOND _changes[] = {
       { 1960,  1,  1.4178180 },
       { 1961,  1,  1.4228180 },
       { 1961,  8,  1.3728180 },
@@ -193,7 +199,13 @@ int eraDat(int iy, int im, int id, double fd, double *deltat)
    };
 
 /* Number of Delta(AT) changes */
-   enum { NDAT = (int) (sizeof changes / sizeof changes[0]) };
+   enum { _NDAT = (int) (sizeof _changes / sizeof _changes[0]) };
+
+/* Initialise leap seconds if needed */
+   if ( NDAT == 0) {
+      NDAT = _NDAT;
+      changes = (eraLEAPSECOND *)_changes;
+   }
 
 /* Miscellaneous local variables */
    int j, i, m;
@@ -243,15 +255,15 @@ int eraDat(int iy, int im, int id, double fd, double *deltat)
 
 }
 /*----------------------------------------------------------------------
-**  
-**  
+**
+**
 **  Copyright (C) 2013-2019, NumFOCUS Foundation.
 **  All rights reserved.
-**  
+**
 **  This library is derived, with permission, from the International
 **  Astronomical Union's "Standards of Fundamental Astronomy" library,
 **  available from http://www.iausofa.org.
-**  
+**
 **  The ERFA version is intended to retain identical functionality to
 **  the SOFA library, but made distinct through different function and
 **  file names, as set out in the SOFA license conditions.  The SOFA
@@ -260,36 +272,36 @@ int eraDat(int iy, int im, int id, double fd, double *deltat)
 **  state.  The ERFA version is not subject to this restriction and
 **  therefore can be included in distributions which do not support the
 **  concept of "read only" software.
-**  
+**
 **  Although the intent is to replicate the SOFA API (other than
 **  replacement of prefix names) and results (with the exception of
 **  bugs;  any that are discovered will be fixed), SOFA is not
 **  responsible for any errors found in this version of the library.
-**  
+**
 **  If you wish to acknowledge the SOFA heritage, please acknowledge
 **  that you are using a library derived from SOFA, rather than SOFA
 **  itself.
-**  
-**  
+**
+**
 **  TERMS AND CONDITIONS
-**  
+**
 **  Redistribution and use in source and binary forms, with or without
 **  modification, are permitted provided that the following conditions
 **  are met:
-**  
+**
 **  1 Redistributions of source code must retain the above copyright
 **    notice, this list of conditions and the following disclaimer.
-**  
+**
 **  2 Redistributions in binary form must reproduce the above copyright
 **    notice, this list of conditions and the following disclaimer in
 **    the documentation and/or other materials provided with the
 **    distribution.
-**  
+**
 **  3 Neither the name of the Standards Of Fundamental Astronomy Board,
 **    the International Astronomical Union nor the names of its
 **    contributors may be used to endorse or promote products derived
 **    from this software without specific prior written permission.
-**  
+**
 **  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 **  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 **  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -302,5 +314,5 @@ int eraDat(int iy, int im, int id, double fd, double *deltat)
 **  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 **  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 **  POSSIBILITY OF SUCH DAMAGE.
-**  
+**
 */

--- a/src/dat.c
+++ b/src/dat.c
@@ -1,13 +1,5 @@
 #include "erfa.h"
-
-static eraLEAPSECOND *changes = 0;
-static int NDAT = 0;
-
-void eraUpdateLeapSeconds(eraLEAPSECOND *leapseconds, int count)
-{
-   changes = leapseconds;
-   NDAT = count;
-}
+#include "erfadatextra.h"
 
 int eraDat(int iy, int im, int id, double fd, double *deltat)
 /*
@@ -201,11 +193,11 @@ int eraDat(int iy, int im, int id, double fd, double *deltat)
 /* Number of Delta(AT) changes */
    enum { _NDAT = (int) (sizeof _changes / sizeof _changes[0]) };
 
-/* Initialise leap seconds if needed */
-   if ( NDAT == 0) {
-      NDAT = _NDAT;
-      changes = (eraLEAPSECOND *)_changes;
-   }
+/* Get/initialise leap-second if needed */
+   int NDAT;
+   eraLEAPSECOND *changes;
+
+   NDAT = eraDatini(_changes, _NDAT, &changes);
 
 /* Miscellaneous local variables */
    int j, i, m;

--- a/src/erfa.h
+++ b/src/erfa.h
@@ -355,6 +355,7 @@ int eraGd2gce(double a, double f,
 /* Astronomy/Timescales */
 int eraD2dtf(const char *scale, int ndp, double d1, double d2,
              int *iy, int *im, int *id, int ihmsf[4]);
+void eraUpdateLeapSeconds(eraLEAPSECOND *leapseconds, int count);
 int eraDat(int iy, int im, int id, double fd, double *deltat);
 double eraDtdb(double date1, double date2,
                double ut, double elong, double u, double v);

--- a/src/erfa.h
+++ b/src/erfa.h
@@ -355,7 +355,6 @@ int eraGd2gce(double a, double f,
 /* Astronomy/Timescales */
 int eraD2dtf(const char *scale, int ndp, double d1, double d2,
              int *iy, int *im, int *id, int ihmsf[4]);
-void eraUpdateLeapSeconds(eraLEAPSECOND *leapseconds, int count);
 int eraDat(int iy, int im, int id, double fd, double *deltat);
 double eraDtdb(double date1, double date2,
                double ut, double elong, double u, double v);

--- a/src/erfadatextra.c
+++ b/src/erfadatextra.c
@@ -1,0 +1,38 @@
+#include "erfa.h"
+#include "erfaextra.h"
+
+static eraLEAPSECOND *changes;
+static int NDAT = 0;
+
+
+int eraGetLeapSeconds(eraLEAPSECOND **leapseconds)
+{
+    if (NDAT == 0) {
+        double delat;
+        int stat = eraDat(2000, 1, 1, 0., &delat);
+        if (stat != 0 || NDAT == 0) {
+            return -1;
+        }
+    }
+    *leapseconds = changes;
+    return NDAT;
+}
+
+void eraSetLeapSeconds(eraLEAPSECOND *leapseconds, int count)
+{
+    changes = leapseconds;
+    NDAT = count;
+}
+
+/*
+ * For internal use in dat.c
+ */
+int eraDatini(const eraLEAPSECOND *builtin, int n_builtin,
+              eraLEAPSECOND **leapseconds)
+{
+    if (NDAT == 0) {
+        eraSetLeapSeconds((eraLEAPSECOND *)builtin, n_builtin);
+    }
+    *leapseconds = changes;
+    return NDAT;
+}

--- a/src/erfadatextra.c
+++ b/src/erfadatextra.c
@@ -1,16 +1,44 @@
+/*
+** Copyright (C) 2019, NumFOCUS Foundation.
+**
+** Licensed under a 3-clause BSD style license - see LICENSE
+**
+** This file is NOT derived from SOFA sources.
+**
+** The eraGetLeapSeconds and eraSetLeapSeconds functions are used as an
+** experimental interface for getting and setting the leap second table in
+** astropy 4.0.  They will be supported as long as astropy 4.0 is supported
+** (until 2021), but not necessarily beyond.  Comments and ideas about the
+** best way to keep the leap second tables up to date for all users of erfa
+** are welcome (https://github.com/liberfa/erfa).
+**
+** The eraDatini function is used internally in dat.c; it is strictly an
+** implementation detail and should not be used elsewhere.
+*/
 #include "erfa.h"
 #include "erfaextra.h"
 
 static eraLEAPSECOND *changes;
-static int NDAT = 0;
+static int NDAT = -1;
 
 
 int eraGetLeapSeconds(eraLEAPSECOND **leapseconds)
+/*
+**  Get the current leap second table.
+**
+**  Returned:
+**     leapseconds eraLEAPSECOND*  Array of year, month, TAI minus UTC
+**
+**  Returned (function value):
+**            int  NDAT  Number of entries/status
+**                       >0 = number of entries
+**                       -1 = internal error
+*/
 {
-    if (NDAT == 0) {
+    if (NDAT <= 0) {
         double delat;
         int stat = eraDat(2000, 1, 1, 0., &delat);
-        if (stat != 0 || NDAT == 0) {
+        if (stat != 0 || NDAT <= 0) {
             return -1;
         }
     }
@@ -19,18 +47,45 @@ int eraGetLeapSeconds(eraLEAPSECOND **leapseconds)
 }
 
 void eraSetLeapSeconds(eraLEAPSECOND *leapseconds, int count)
+/*
+**  Set the current leap second table.
+**
+**  Given:
+**     leapseconds eraLEAPSECOND*  Array of year, month, TAI minus UTC
+**     count       int             Number of entries.  If <= 0, causes
+**                                 a reset of the table to the built-in
+**                                 version.
+**
+**  Notes:
+**     *No* sanity checks are performed.
+*/
 {
     changes = leapseconds;
     NDAT = count;
 }
 
-/*
- * For internal use in dat.c
- */
 int eraDatini(const eraLEAPSECOND *builtin, int n_builtin,
               eraLEAPSECOND **leapseconds)
+/*
+**  Get the leap second table, initializing it to the built-in version
+**  if necessary.
+**
+**  This function is for internal use in dat.c only and should
+**  not be used elsewhere.
+**
+**  Given:
+**     builtin     eraLEAPSECOND   Array of year, month, TAI minus UTC
+**     n_builtin   int             Number of entries of the table.
+**
+**  Returned:
+**     leapseconds eraLEAPSECOND*  Current array, set to the builtin one
+**                                 if not yet initialized.
+**
+**  Returned (function value):
+**            int  NDAT  Number of entries
+*/
 {
-    if (NDAT == 0) {
+    if (NDAT <= 0) {
         eraSetLeapSeconds((eraLEAPSECOND *)builtin, n_builtin);
     }
     *leapseconds = changes;

--- a/src/erfadatextra.h
+++ b/src/erfadatextra.h
@@ -1,0 +1,2 @@
+int eraDatini(const eraLEAPSECOND *builtin, int n_builtin,
+              eraLEAPSECOND **leapseconds);

--- a/src/erfadatextra.h
+++ b/src/erfadatextra.h
@@ -1,2 +1,18 @@
+/*
+** Copyright (C) 2016-2017, NumFOCUS Foundation.
+**
+** Licensed under a 3-clause BSD style license - see LICENSE
+**
+** This file is NOT derived from SOFA sources.
+**
+*/
+
+/*
+**  Get the leap second table, initializing it to the built-in version
+**  if necessary.
+**
+**  This function is for internal use in dat.c only and should
+**  not be used elsewhere.
+*/
 int eraDatini(const eraLEAPSECOND *builtin, int n_builtin,
               eraLEAPSECOND **leapseconds);

--- a/src/erfadatextra.h
+++ b/src/erfadatextra.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (C) 2016-2017, NumFOCUS Foundation.
+** Copyright (C) 2019, NumFOCUS Foundation.
 **
 ** Licensed under a 3-clause BSD style license - see LICENSE
 **

--- a/src/erfaextra.h
+++ b/src/erfaextra.h
@@ -1,9 +1,20 @@
 /*
-** Copyright (C) 2016-2017, NumFOCUS Foundation.
+** Copyright (C) 2016-2019, NumFOCUS Foundation.
 **
 ** Licensed under a 3-clause BSD style license - see LICENSE
 **
-** This file is NOT derived from SOFA sources
+** This file is NOT derived from SOFA sources.
+**
+** The functions here provide an interface to ERFA and SOFA version
+** information, and for updating the leap second table.
+**
+** The eraGetLeapSeconds and eraSetLeapSeconds functions are used as an
+** experimental interface for getting and setting the leap second table in
+** astropy 4.0.  They will be supported as long as astropy 4.0 is supported
+** (until 2021), but not necessarily beyond.  Comments and ideas about the
+** best way to keep the leap second tables up to date for all users of erfa
+** are welcome (https://github.com/liberfa/erfa).
+**
 */
 
 
@@ -51,9 +62,8 @@ int eraVersionMicro(void);
 const char* eraSofaVersion(void);
 
 
-
 /*
-** Get and set leap seconds (not supported by SOFA)
+** Get and set leap seconds (not supported by SOFA; EXPERIMENTAL)
 */
 int eraGetLeapSeconds(eraLEAPSECOND **leapseconds);
 void eraSetLeapSeconds(eraLEAPSECOND *leapseconds, int count);

--- a/src/erfaextra.h
+++ b/src/erfaextra.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (C) 2016-2017, NumFOCUS Foundation. 
+** Copyright (C) 2016-2017, NumFOCUS Foundation.
 **
 ** Licensed under a 3-clause BSD style license - see LICENSE
 **
@@ -15,45 +15,51 @@ extern "C" {
 #endif
 
 
-/* 
+/*
 ** Returns the package version
 ** as defined in configure.ac
 ** in string format
 */
-const char* eraVersion();
+const char* eraVersion(void);
 
-/* 
+/*
 ** Returns the package major version
 ** as defined in configure.ac
 ** as integer
 */
-int eraVersionMajor();
+int eraVersionMajor(void);
 
-/* 
+/*
 ** Returns the package minor version
 ** as defined in configure.ac
 ** as integer
 */
-int eraVersionMinor();
+int eraVersionMinor(void);
 
-/* 
+/*
 ** Returns the package micro version
 ** as defined in configure.ac
 ** as integer
 */
-int eraVersionMicro();
+int eraVersionMicro(void);
 
-/* 
+/*
 ** Returns the orresponding SOFA version
 ** as defined in configure.ac
 ** in string format
 */
-const char* eraSofaVersion();
+const char* eraSofaVersion(void);
 
+
+
+/*
+** Get and set leap seconds (not supported by SOFA)
+*/
+int eraGetLeapSeconds(eraLEAPSECOND **leapseconds);
+void eraSetLeapSeconds(eraLEAPSECOND *leapseconds, int count);
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* _ERFA_EXTRA_H */
-

--- a/src/erfam.h
+++ b/src/erfam.h
@@ -41,6 +41,12 @@ typedef struct {
    double pv[2][3];   /* barycentric PV of the body (au, au/day) */
 } eraLDBODY;
 
+/* Leap second definition */
+typedef struct {
+   int iyear, month;
+   double delat;
+} eraLEAPSECOND;
+
 /* Pi */
 #define ERFA_DPI (3.141592653589793238462643)
 

--- a/src/erfaversion.c
+++ b/src/erfaversion.c
@@ -1,38 +1,51 @@
 /*
 ** Copyright (C) 2016-2017, NumFOCUS Foundation.
 **
-** Licensed under a 3-clause BSD style license - see LICENSE 
+** Licensed under a 3-clause BSD style license - see LICENSE
 **
 ** This file is NOT derived from SOFA sources
 */
 
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "1.6.0"
+
+/* Define to the major version of this package. */
+#define PACKAGE_VERSION_MAJOR 1
+
+/* Define to the micro version of this package. */
+#define PACKAGE_VERSION_MICRO 0
+
+/* Define to the minor version of this package. */
+#define PACKAGE_VERSION_MINOR 6
+
+/* Define to the version of SOFA */
+#define SOFA_VERSION "20190722"
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
 
 
-const char* eraVersion() {
+const char* eraVersion(void) {
   return PACKAGE_VERSION;
 }
 
 
-int eraVersionMajor() {
+int eraVersionMajor(void) {
   return PACKAGE_VERSION_MAJOR;
 }
 
 
-int eraVersionMinor() {
+int eraVersionMinor(void) {
   return PACKAGE_VERSION_MINOR;
 }
 
 
-int eraVersionMicro() {
+int eraVersionMicro(void) {
   return PACKAGE_VERSION_MICRO;
 }
 
 
-const char* eraSofaVersion() {
+const char* eraSofaVersion(void) {
   return SOFA_VERSION;
 }
-

--- a/src/t_erfa_c_extra.c
+++ b/src/t_erfa_c_extra.c
@@ -50,7 +50,7 @@ static void t_versions(int *status)
   }
 
   if (*status == 0) {
-    printf("t_versions passed");
+    printf("t_versions passed\n");
   }
 
 }
@@ -70,7 +70,7 @@ static void t_leap_seconds(int *status)
   count_postset = eraGetLeapSeconds(&leapseconds_postset);
 
   if (count_postset == (count_init+1)) {
-    printf("t_leap_seconds passed");
+    printf("t_leap_seconds passed\n");
   } else {
     *status = 1;
     printf("t_leap_seconds failed - after adding one change, leap second table has %d entries instead of %d\n", leapseconds_postset, count_init+1);

--- a/src/t_erfa_c_extra.c
+++ b/src/t_erfa_c_extra.c
@@ -19,81 +19,6 @@ static int verbose = 0;
 **
 */
 
-static void viv(int ival, int ivalok,
-                const char *func, const char *test, int *status)
-/*
-**  - - - -
-**   v i v
-**  - - - -
-**
-**  Validate an integer result.
-**
-**  Internal function used by t_erfa_c program.
-**
-**  Given:
-**     ival     int          value computed by function under test
-**     ivalok   int          correct value
-**     func     char[]       name of function under test
-**     test     char[]       name of individual test
-**
-**  Given and returned:
-**     status   int          set to TRUE if test fails
-**
-**  This revision:  2013 August 7
-*/
-{
-   if (ival != ivalok) {
-      *status = 1;
-      printf("%s failed: %s want %d got %d\n",
-             func, test, ivalok, ival);
-   } else if (verbose) {
-      printf("%s passed: %s want %d got %d\n",
-                    func, test, ivalok, ival);
-   }
-
-}
-
-static void vvd(double val, double valok, double dval,
-                const char *func, const char *test, int *status)
-/*
-**  - - - -
-**   v v d
-**  - - - -
-**
-**  Validate a double result.
-**
-**  Internal function used by t_erfa_c program.
-**
-**  Given:
-**     val      double       value computed by function under test
-**     valok    double       expected value
-**     dval     double       maximum allowable error
-**     func     char[]       name of function under test
-**     test     char[]       name of individual test
-**
-**  Given and returned:
-**     status   int          set to TRUE if test fails
-**
-**  This revision:  2016 April 21
-*/
-{
-   double a, f;   /* absolute and fractional error */
-
-
-   a = val - valok;
-   if (a != 0.0 && fabs(a) > fabs(dval)) {
-      f = fabs(valok / a);
-      *status = 1;
-      printf("%s failed: %s want %.20g got %.20g (1/%.3g)\n",
-             func, test, valok, val, f);
-   } else if (verbose) {
-      printf("%s passed: %s want %.20g got %.20g\n",
-             func, test, valok, val);
-   }
-
-}
-
-
 static void t_versions(int *status)
 /*
 **  Test that the version-checking functions yield something.
@@ -135,7 +60,21 @@ static void t_leap_seconds(int *status)
 **  Test that the leap-second machinery yields something
 */
 {
+  int count_init, count_postset;
+  eraLEAPSECOND* leapseconds_init;
+  eraLEAPSECOND* leapseconds_postset;
+  eraLEAPSECOND new_leapsecond[1] = {{ 2050, 5, 35. }};
 
+  count_init = eraGetLeapSeconds(&leapseconds_init);
+  eraSetLeapSeconds(&new_leapsecond, 1);
+  count_postset = eraGetLeapSeconds(&leapseconds_postset);
+
+  if (count_postset == (count_init+1)) {
+    printf("t_leap_seconds passed");
+  } else {
+    *status = 1;
+    printf("t_leap_seconds failed - after adding one change, leap second table has %d entries instead of %d\n", leapseconds_postset, count_init+1);
+  }
 }
 
 int main(int argc, char *argv[])

--- a/src/t_erfa_c_extra.c
+++ b/src/t_erfa_c_extra.c
@@ -32,21 +32,21 @@ static void t_versions(int *status)
   res = strstr(version_str, buf);
   if (!res) {
     *status = 1;
-    printf("t_versions failed - major version %d not in version string %s\n", res, version_str);
+    printf("t_versions failed - major version not in version string %s\n", version_str);
   }
 
   sprintf(buf, "%d", eraVersionMinor());
   res = strstr(version_str, buf);
   if (!res) {
     *status = 1;
-    printf("t_versions failed - minor version %d not in version string %s\n", res, version_str);
+    printf("t_versions failed - minor version not in version string %s\n", version_str);
   }
 
   sprintf(buf, "%d", eraVersionMicro());
   res = strstr(version_str, buf);
   if (!res) {
     *status = 1;
-    printf("t_versions failed - micro version %d not in version string %s\n", res, version_str);
+    printf("t_versions failed - micro version not in version string %s\n", version_str);
   }
 
   if (*status == 0) {

--- a/src/t_erfa_c_extra.c
+++ b/src/t_erfa_c_extra.c
@@ -1,0 +1,228 @@
+/*
+** Copyright (C) 2019, NumFOCUS Foundation.
+**
+** Licensed under a 3-clause BSD style license - see LICENSE
+**
+** This file is NOT derived from SOFA sources.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <erfa.h>
+#include <erfaextra.h>
+
+static int verbose = 0;
+
+/*
+**
+**  Validate the ERFA C functions that are not derived from SOFA (SOFA-derived tests are in t_erfa_c)
+**
+*/
+
+static void viv(int ival, int ivalok,
+                const char *func, const char *test, int *status)
+/*
+**  - - - -
+**   v i v
+**  - - - -
+**
+**  Validate an integer result.
+**
+**  Internal function used by t_erfa_c program.
+**
+**  Given:
+**     ival     int          value computed by function under test
+**     ivalok   int          correct value
+**     func     char[]       name of function under test
+**     test     char[]       name of individual test
+**
+**  Given and returned:
+**     status   int          set to TRUE if test fails
+**
+**  This revision:  2013 August 7
+*/
+{
+   if (ival != ivalok) {
+      *status = 1;
+      printf("%s failed: %s want %d got %d\n",
+             func, test, ivalok, ival);
+   } else if (verbose) {
+      printf("%s passed: %s want %d got %d\n",
+                    func, test, ivalok, ival);
+   }
+
+}
+
+static void vvd(double val, double valok, double dval,
+                const char *func, const char *test, int *status)
+/*
+**  - - - -
+**   v v d
+**  - - - -
+**
+**  Validate a double result.
+**
+**  Internal function used by t_erfa_c program.
+**
+**  Given:
+**     val      double       value computed by function under test
+**     valok    double       expected value
+**     dval     double       maximum allowable error
+**     func     char[]       name of function under test
+**     test     char[]       name of individual test
+**
+**  Given and returned:
+**     status   int          set to TRUE if test fails
+**
+**  This revision:  2016 April 21
+*/
+{
+   double a, f;   /* absolute and fractional error */
+
+
+   a = val - valok;
+   if (a != 0.0 && fabs(a) > fabs(dval)) {
+      f = fabs(valok / a);
+      *status = 1;
+      printf("%s failed: %s want %.20g got %.20g (1/%.3g)\n",
+             func, test, valok, val, f);
+   } else if (verbose) {
+      printf("%s passed: %s want %.20g got %.20g\n",
+             func, test, valok, val);
+   }
+
+}
+
+
+static void t_versions(int *status)
+/*
+**  Test that the version-checking functions yield something.
+*/
+{
+  char buf[3];
+  char* res;
+  const char* version_str = eraVersion();
+
+  sprintf(buf, "%d", eraVersionMajor());
+  res = strstr(version_str, buf);
+  if (!res) {
+    *status = 1;
+    printf("t_versions failed - major version %d not in version string %s\n", res, version_str);
+  }
+
+  sprintf(buf, "%d", eraVersionMinor());
+  res = strstr(version_str, buf);
+  if (!res) {
+    *status = 1;
+    printf("t_versions failed - minor version %d not in version string %s\n", res, version_str);
+  }
+
+  sprintf(buf, "%d", eraVersionMicro());
+  res = strstr(version_str, buf);
+  if (!res) {
+    *status = 1;
+    printf("t_versions failed - micro version %d not in version string %s\n", res, version_str);
+  }
+
+  if (*status == 0) {
+    printf("t_versions passed");
+  }
+
+}
+
+static void t_leap_seconds(int *status)
+/*
+**  Test that the leap-second machinery yields something
+*/
+{
+
+}
+
+int main(int argc, char *argv[])
+{
+   int status;
+
+
+/* If any command-line argument, switch to verbose reporting. */
+   if (argc > 1) {
+      verbose = 1;
+      argv[0][0] += 0;    /* to avoid compiler warnings */
+   }
+
+/* Preset the &status to FALSE = success. */
+   status = 0;
+
+/* Test all of the extra functions. */
+   t_versions(&status);
+   t_leap_seconds(&status);
+
+/* Report, set up an appropriate exit status, and finish. */
+   if (status) {
+      printf("t_erfa_c_extra validation failed!\n");
+   } else {
+      printf("t_erfa_c_extra validation successful\n");
+   }
+   return status;
+}
+/*----------------------------------------------------------------------
+**  
+**  
+**  Copyright (C) 2013-2019, NumFOCUS Foundation.
+**  All rights reserved.
+**  
+**  This library is derived, with permission, from the International
+**  Astronomical Union's "Standards of Fundamental Astronomy" library,
+**  available from http://www.iausofa.org.
+**  
+**  The ERFA version is intended to retain identical functionality to
+**  the SOFA library, but made distinct through different function and
+**  file names, as set out in the SOFA license conditions.  The SOFA
+**  original has a role as a reference standard for the IAU and IERS,
+**  and consequently redistribution is permitted only in its unaltered
+**  state.  The ERFA version is not subject to this restriction and
+**  therefore can be included in distributions which do not support the
+**  concept of "read only" software.
+**  
+**  Although the intent is to replicate the SOFA API (other than
+**  replacement of prefix names) and results (with the exception of
+**  bugs;  any that are discovered will be fixed), SOFA is not
+**  responsible for any errors found in this version of the library.
+**  
+**  If you wish to acknowledge the SOFA heritage, please acknowledge
+**  that you are using a library derived from SOFA, rather than SOFA
+**  itself.
+**  
+**  
+**  TERMS AND CONDITIONS
+**  
+**  Redistribution and use in source and binary forms, with or without
+**  modification, are permitted provided that the following conditions
+**  are met:
+**  
+**  1 Redistributions of source code must retain the above copyright
+**    notice, this list of conditions and the following disclaimer.
+**  
+**  2 Redistributions in binary form must reproduce the above copyright
+**    notice, this list of conditions and the following disclaimer in
+**    the documentation and/or other materials provided with the
+**    distribution.
+**  
+**  3 Neither the name of the Standards Of Fundamental Astronomy Board,
+**    the International Astronomical Union nor the names of its
+**    contributors may be used to endorse or promote products derived
+**    from this software without specific prior written permission.
+**  
+**  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+**  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+**  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+**  FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+**  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+**  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+**  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+**  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+**  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+**  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+**  POSSIBILITY OF SUCH DAMAGE.
+**  
+*/

--- a/src/t_erfa_c_extra.c
+++ b/src/t_erfa_c_extra.c
@@ -60,20 +60,33 @@ static void t_leap_seconds(int *status)
 **  Test that the leap-second machinery yields something
 */
 {
-  int count_init, count_postset;
+  int count_init, count_postset, count_postreset;
   eraLEAPSECOND* leapseconds_init;
   eraLEAPSECOND* leapseconds_postset;
-  eraLEAPSECOND new_leapsecond[1] = {{ 2050, 5, 35. }};
+  eraLEAPSECOND* leapseconds_postreset;
+
+  eraLEAPSECOND fake_leapsecond[1] = {{ 2050, 5, 55.0 }};
 
   count_init = eraGetLeapSeconds(&leapseconds_init);
-  eraSetLeapSeconds(new_leapsecond, 1);
+
+  eraSetLeapSeconds(fake_leapsecond, 1);
   count_postset = eraGetLeapSeconds(&leapseconds_postset);
 
-  if (count_postset == (count_init+1)) {
-    printf("t_leap_seconds passed\n");
+  if (count_postset == 1) {
+    printf("t_leap_seconds set passed\n");
   } else {
     *status = 1;
-    printf("t_leap_seconds failed - after adding one change, leap second table has %d entries instead of %d\n", leapseconds_postset, count_init+1);
+    printf("t_leap_seconds set failed - leap second table has %d entries instead of %d\n", count_postreset, 1);
+  }
+
+  eraSetLeapSeconds(fake_leapsecond, -1);
+  count_postreset = eraGetLeapSeconds(&leapseconds_postreset);
+
+  if (count_postreset == count_init) {
+    printf("t_leap_seconds reset passed\n");
+  } else {
+    *status = 1;
+    printf("t_leap_seconds reset failed - leap second table has %d entries instead of %d\n", count_postreset, count_init);
   }
 }
 

--- a/src/t_erfa_c_extra.c
+++ b/src/t_erfa_c_extra.c
@@ -66,7 +66,7 @@ static void t_leap_seconds(int *status)
   eraLEAPSECOND new_leapsecond[1] = {{ 2050, 5, 35. }};
 
   count_init = eraGetLeapSeconds(&leapseconds_init);
-  eraSetLeapSeconds(&new_leapsecond, 1);
+  eraSetLeapSeconds(new_leapsecond, 1);
   count_postset = eraGetLeapSeconds(&leapseconds_postset);
 
   if (count_postset == (count_init+1)) {


### PR DESCRIPTION
This builds on #49 to allow accessing and replacing the leap second table, using the implementation we ended up using in astropy.

@eteq - I fear we do have to ship with this, noting this is experimental... But I think it is the right building block to add a way of updating leap seconds inside `erfa` here.

@olebole - if you can, could you check that this PR does make an external liberfa work with astropy 4.0?