### PR TITLE
Add note that the erfaversion.c needs updating

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -162,7 +162,7 @@ If the version is given in the form MAJOR.MINOR.PATCH, then
         you are either fixing a bug or making other improvements. Increase
         patch by one and do not change the others.
 
-Change the version number in the `AC_INIT` macro and in `README.rst`
+Change the version number in `README.rst`, the `AC_INIT` macro, and the macros in `src/erfaversion.c`.
 
 Shared library version info
 ---------------------------


### PR DESCRIPTION
This PR addresses the underlying problem that led to #62 : that I followed the instructions for updating which were never updated to mention ``erfaversion.c`` - now it says clearly to check that in addition to the readme and AC_INIT .