### PR TITLE
Cleanup version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ in this source distribution.
 Differences from SOFA
 ---------------------
 
-This version of ERFA (v1.7.1) is based on SOFA version "20200721", with the
+This version of ERFA (v1.7.2) is based on SOFA version "20200721", with the
 differences outlined below.
 
 ERFA branding
@@ -51,6 +51,14 @@ Bug fixes
 
 ERFA includes smaller changes that may or may not eventually make it into SOFA,
 addressing localized bugs or similar smaller issues:
+
+* ERFA 1.7.2 and SOFA "20200721"
+
+  + Only bug fixes in the SOFA release.  The only differences between ERFA 1.7.2
+    and SOFA "20200721" remain the added ``eraVersion``, ``eraSofaVersion``, and
+    leap second functions noted above.
+  + Fixes a bug in ERFA 1.7.1 that ``eraVersion`` would return 1.7.0 if
+    compiled directly rather than created as part of the library with ``make``.
 
 * ERFA 1.7.1 and SOFA "20200721"
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -68,6 +68,9 @@ permissions.
   described above).  Ensure the list of changes is accurate for this new
   version.
 
+* Also update the version in ``src/erfaversion.c``, in all relevant ``#define``
+  statements.
+
 * Commit these changes using ``git commit``, with a commit message like
   ``Preparing release v0.0.1``.
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 
 AC_PREREQ([2.68])
 ## Follow the instructions in RELEASE.rst to change package version
-AC_INIT([erfa],[1.7.1])
+AC_INIT([erfa],[1.7.2])
 AC_CONFIG_SRCDIR([src/erfa.h])
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([m4])
@@ -17,7 +17,7 @@ ERFA_NUMVER
 ## A library supports interfaces from current downto current - age
 ## Revision is the version of the current interface
 ## Follow the instructions in RELEASE.rst to change the version info
-ERFA_LIB_VERSION_INFO(8, 1, 7)
+ERFA_LIB_VERSION_INFO(8, 2, 7)
 
 ## SOFA version, update if needed in new relases
 AC_DEFINE([SOFA_VERSION], ["20200721"], [Define to the version of SOFA])

--- a/src/erfaversion.c
+++ b/src/erfaversion.c
@@ -7,16 +7,16 @@
 */
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.7.0"
+#define PACKAGE_VERSION "1.7.2"
 
 /* Define to the major version of this package. */
 #define PACKAGE_VERSION_MAJOR 1
 
-/* Define to the micro version of this package. */
-#define PACKAGE_VERSION_MICRO 0
-
 /* Define to the minor version of this package. */
 #define PACKAGE_VERSION_MINOR 7
+
+/* Define to the micro version of this package. */
+#define PACKAGE_VERSION_MICRO 2
 
 /* Define to the version of SOFA */
 #define SOFA_VERSION "20190722"


### PR DESCRIPTION
Arrgghh, after releasing and testing with pyerfa, I find out that I forgot to also update the version returned by the C functions. So, we need to do a bug-fix 1.7.2.

This PR also updates the release instructions, although really we should try to ensure that a given release number only has to be entered once!!