### PR TITLE
Single way to get version info

### DIFF
--- a/src/erfaextra.h
+++ b/src/erfaextra.h
@@ -21,6 +21,8 @@
 #ifndef _ERFA_EXTRA_H
 #define _ERFA_EXTRA_H
 
+#include "erfam.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/erfaversion.c
+++ b/src/erfaversion.c
@@ -6,21 +6,12 @@
 ** This file is NOT derived from SOFA sources
 */
 
-/* Define to the version of this package. */
-#define PACKAGE_VERSION "1.7.0"
-
-/* Define to the major version of this package. */
-#define PACKAGE_VERSION_MAJOR 1
-
-/* Define to the micro version of this package. */
-#define PACKAGE_VERSION_MICRO 0
-
-/* Define to the minor version of this package. */
-#define PACKAGE_VERSION_MINOR 7
-
-/* Define to the version of SOFA */
-#define SOFA_VERSION "20190722"
-
+/*
+ * config.h defines the version information macros;
+ * it is auto-generated in the autotools build process.
+ * without it, the macros have to be defined explicitly
+ * in the call to the compiler.
+ */
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif /* HAVE_CONFIG_H */


### PR DESCRIPTION
Follows @sergiopasra's suggestion to just remove the backup version definitions, i.e., rely on autotools being used.

Also fixes a missing import in `erfaextra.h`, following https://github.com/liberfa/erfa/pull/73#issuecomment-695997742