### PR TITLE
Update to sofa 18

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ in this source distribution.
 Differences from SOFA
 ---------------------
 
-This version of ERFA (v1.7.3) is based on SOFA version "20210125_a", with the
+This version of ERFA (v2.0.0) is based on SOFA version "20210512", with the
 differences outlined below.
 
 ERFA branding
@@ -51,6 +51,15 @@ Bug fixes
 
 ERFA includes smaller changes that may or may not eventually make it into SOFA,
 addressing localized bugs or similar smaller issues:
+
+* ERFA 2.0.0 and SOFA "20210512"
+
+  + Functionally, there no differences except for the added ``eraVersion``,
+    ``eraSofaVersion``, and leap second functions noted above.
+  + The three new functions added in SOFA are added to ERFA as well.
+  + Like for SOFA, one now has to explicitly include ``erfam.h`` to use its
+    macros defining constants, etc. Including just ``erfa.h`` (or
+    ``erfaextra.h``) will no longer includes ``erfam.h`` implicitly.
 
 * ERFA 1.7.3 and SOFA "20210125_a"
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 
 AC_PREREQ([2.68])
 ## Follow the instructions in RELEASE.rst to change package version
-AC_INIT([erfa],[1.7.3])
+AC_INIT([erfa],[2.0.0])
 AC_CONFIG_SRCDIR([src/erfa.h])
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([m4])
@@ -17,10 +17,10 @@ ERFA_NUMVER
 ## A library supports interfaces from current downto current - age
 ## Revision is the version of the current interface
 ## Follow the instructions in RELEASE.rst to change the version info
-ERFA_LIB_VERSION_INFO(8, 3, 7)
+ERFA_LIB_VERSION_INFO(9, 0, 8)
 
 ## SOFA version, update if needed in new relases
-AC_DEFINE([SOFA_VERSION], ["20210125_a"], [Define to the version of SOFA])
+AC_DEFINE([SOFA_VERSION], ["20210512"], [Define to the version of SOFA])
 
 # Checks for libraries.
 AC_SEARCH_LIBS([sin], [m], , AC_MSG_ERROR([cannot find math functions]))

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,8 @@
 lib_LTLIBRARIES = liberfa.la
 liberfa_la_SOURCES = a2af.c a2tf.c ab.c ae2hd.c af2a.c anp.c anpm.c apcg13.c \
 apcg.c apci13.c apci.c apco13.c apco.c apcs13.c apcs.c aper13.c \
-aper.c apio13.c apio.c atci13.c atciq.c atciqn.c atciqz.c atco13.c \
+aper.c apio13.c apio.c atcc13.c atccq.c \
+atci13.c atciq.c atciqn.c atciqz.c atco13.c \
 atic13.c aticq.c aticqn.c atio13.c atioq.c atoc13.c atoi13.c atoiq.c \
 bi00.c bp00.c bp06.c bpn2xy.c c2i00a.c c2i00b.c c2i06a.c c2ibpn.c \
 c2ixy.c c2ixys.c c2s.c c2t00a.c c2t00b.c c2t06a.c c2tcio.c c2teqx.c \
@@ -16,6 +17,7 @@ gd2gce.c gmst00.c gmst06.c gmst82.c gst00a.c gst00b.c gst06a.c \
 gst06.c gst94.c hd2ae.c hd2pa.c h2fk5.c hfk5z.c icrs2g.c ir.c \
 jd2cal.c jdcalf.c ld.c \
 ldn.c ldsun.c lteceq.c ltecm.c lteqec.c ltpb.c ltp.c ltpecl.c ltpequ.c \
+moon98.c \
 num00a.c num00b.c num06a.c numat.c nut00a.c nut00b.c \
 nut06a.c nut80.c nutm80.c obl06.c obl80.c p06e.c p2pv.c p2s.c pap.c \
 pas.c pb06.c pdp.c pfw06.c plan94.c pmat00.c pmat06.c pmat76.c \

--- a/src/a2af.c
+++ b/src/a2af.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraA2af(int ndp, double angle, char *sign, int idmsf[4])
 /*
@@ -51,7 +52,7 @@ void eraA2af(int ndp, double angle, char *sign, int idmsf[4])
 **  Called:
 **     eraD2tf      decompose days to hms
 **
-**  This revision:  2020 April 1
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -64,7 +65,7 @@ void eraA2af(int ndp, double angle, char *sign, int idmsf[4])
 /* Scale then use days to h,m,s function. */
    eraD2tf(ndp, angle*F, sign, idmsf);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/a2tf.c
+++ b/src/a2tf.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraA2tf(int ndp, double angle, char *sign, int ihmsf[4])
 /*
@@ -51,7 +52,7 @@ void eraA2tf(int ndp, double angle, char *sign, int ihmsf[4])
 **  Called:
 **     eraD2tf      decompose days to hms
 **
-**  This revision:  2020 April 1
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -60,7 +61,7 @@ void eraA2tf(int ndp, double angle, char *sign, int ihmsf[4])
 /* Scale then use days to h,m,s function. */
    eraD2tf(ndp, angle/ERFA_D2PI, sign, ihmsf);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ab.c
+++ b/src/ab.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraAb(double pnat[3], double v[3], double s, double bm1,
            double ppr[3])
@@ -48,7 +49,7 @@ void eraAb(double pnat[3], double v[3], double s, double bm1,
 **  Called:
 **     eraPdp       scalar product of two p-vectors
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 February 24
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/ae2hd.c
+++ b/src/ae2hd.c
@@ -59,7 +59,7 @@ void eraAe2hd (double az, double el, double phi,
 **
 **  Last revision:   2017 September 12
 **
-**  ERFA release 2021-01-25
+**  ERFA release 2021-05-12
 **
 **  Copyright (C) 2021 IAU ERFA Board.  See notes at end.
 */

--- a/src/af2a.c
+++ b/src/af2a.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 #include <stdlib.h>
 
 int eraAf2a(char s, int ideg, int iamin, double asec, double *rad)
@@ -34,7 +35,7 @@ int eraAf2a(char s, int ideg, int iamin, double asec, double *rad)
 **  3)  If there are multiple errors, the status value reflects only the
 **      first, the smallest taking precedence.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -52,6 +53,8 @@ int eraAf2a(char s, int ideg, int iamin, double asec, double *rad)
    if ( iamin < 0 || iamin > 59 ) return 2;
    if ( asec < 0.0 || asec >= 60.0 ) return 3;
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/anp.c
+++ b/src/anp.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraAnp(double a)
 /*
@@ -14,7 +15,7 @@ double eraAnp(double a)
 **  Returned (function value):
 **              double     angle in range 0-2pi
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -27,6 +28,8 @@ double eraAnp(double a)
    if (w < 0) w += ERFA_D2PI;
 
    return w;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/anpm.c
+++ b/src/anpm.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraAnpm(double a)
 /*
@@ -14,7 +15,7 @@ double eraAnpm(double a)
 **  Returned (function value):
 **              double     angle in range +/-pi
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -27,6 +28,8 @@ double eraAnpm(double a)
    if (fabs(w) >= ERFA_DPI) w -= ERFA_DSIGN(ERFA_D2PI, a);
 
    return w;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/apco.c
+++ b/src/apco.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraApco(double date1, double date2,
              double ebpv[2][3], double ehp[3],
@@ -159,7 +160,7 @@ void eraApco(double date1, double date2,
 **     eraApcs      astrometry parameters, ICRS-GCRS, space observer
 **     eraCr        copy r-matrix
 **
-**  This revision:   2021 January 7
+**  This revision:   2021 February 24
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/apco13.c
+++ b/src/apco13.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraApco13(double utc1, double utc2, double dut1,
               double elong, double phi, double hm, double xp, double yp,
@@ -173,7 +174,7 @@ int eraApco13(double utc1, double utc2, double dut1,
 **     eraApco      astrometry parameters, ICRS-observed
 **     eraEors      equation of the origins, given NPB matrix and s
 **
-**  This revision:   2013 December 5
+**  This revision:   2021 February 24
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/apcs.c
+++ b/src/apcs.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraApcs(double date1, double date2, double pv[2][3],
              double ebpv[2][3], double ehp[3],
@@ -122,7 +123,7 @@ void eraApcs(double date1, double date2, double pv[2][3],
 **     eraPn        decompose p-vector into modulus and direction
 **     eraIr        initialize r-matrix to identity
 **
-**  This revision:   2017 March 16
+**  This revision:   2021 February 24
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/apio.c
+++ b/src/apio.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraApio(double sp, double theta,
              double elong, double phi, double hm, double xp, double yp,
@@ -117,7 +118,7 @@ void eraApio(double sp, double theta,
 **     eraAnpm      normalize angle into range +/- pi
 **     eraPvtob     position/velocity of terrestrial station
 **
-**  This revision:   2021 January 7
+**  This revision:   2021 February 24
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/apio13.c
+++ b/src/apio13.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraApio13(double utc1, double utc2, double dut1,
               double elong, double phi, double hm, double xp, double yp,
@@ -162,7 +163,7 @@ int eraApio13(double utc1, double utc2, double dut1,
 **     eraRefco     refraction constants for given ambient conditions
 **     eraApio      astrometry parameters, CIRS-observed
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 February 24
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/atci13.c
+++ b/src/atci13.c
@@ -14,7 +14,7 @@ void eraAtci13(double rc, double dc,
 **  Given:
 **     rc     double   ICRS right ascension at J2000.0 (radians, Note 1)
 **     dc     double   ICRS declination at J2000.0 (radians, Note 1)
-**     pr     double   RA proper motion (radians/year; Note 2)
+**     pr     double   RA proper motion (radians/year, Note 2)
 **     pd     double   Dec proper motion (radians/year)
 **     px     double   parallax (arcsec)
 **     rv     double   radial velocity (km/s, +ve if receding)
@@ -78,7 +78,7 @@ void eraAtci13(double rc, double dc,
 **     eraApci13    astrometry parameters, ICRS-CIRS, 2013
 **     eraAtciq     quick ICRS to CIRS
 **
-**  This revision:   2017 March 12
+**  This revision:   2021 April 3
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/atciq.c
+++ b/src/atciq.c
@@ -20,8 +20,8 @@ void eraAtciq(double rc, double dc,
 **  can be used instead.
 **
 **  Given:
-**     rc,dc  double     ICRS RA,Dec at J2000.0 (radians)
-**     pr     double     RA proper motion (radians/year; Note 3)
+**     rc,dc  double     ICRS RA,Dec at J2000.0 (radians, Note 1)
+**     pr     double     RA proper motion (radians/year, Note 2)
 **     pd     double     Dec proper motion (radians/year)
 **     px     double     parallax (arcsec)
 **     rv     double     radial velocity (km/s, +ve if receding)
@@ -48,13 +48,11 @@ void eraAtciq(double rc, double dc,
 **
 **  Notes:
 **
-**  1) All the vectors are with respect to BCRS axes.
-**
-**  2) Star data for an epoch other than J2000.0 (for example from the
+**  1) Star data for an epoch other than J2000.0 (for example from the
 **     Hipparcos catalog, which has an epoch of J1991.25) will require a
 **     preliminary call to eraPmsafe before use.
 **
-**  3) The proper motion in RA is dRA/dt rather than cos(Dec)*dRA/dt.
+**  2) The proper motion in RA is dRA/dt rather than cos(Dec)*dRA/dt.
 **
 **  Called:
 **     eraPmpx      proper motion and parallax
@@ -64,7 +62,7 @@ void eraAtciq(double rc, double dc,
 **     eraC2s       p-vector to spherical
 **     eraAnp       normalize angle into range 0 to 2pi
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 April 19
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/atciqn.c
+++ b/src/atciqn.c
@@ -25,7 +25,7 @@ void eraAtciqn(double rc, double dc, double pr, double pd,
 **
 **  Given:
 **     rc,dc  double       ICRS RA,Dec at J2000.0 (radians)
-**     pr     double       RA proper motion (radians/year; Note 3)
+**     pr     double       RA proper motion (radians/year, Note 3)
 **     pd     double       Dec proper motion (radians/year)
 **     px     double       parallax (arcsec)
 **     rv     double       radial velocity (km/s, +ve if receding)
@@ -101,7 +101,7 @@ void eraAtciqn(double rc, double dc, double pr, double pd,
 **     eraC2s       p-vector to spherical
 **     eraAnp       normalize angle into range 0 to 2pi
 **
-**  This revision:   2021 January 6
+**  This revision:   2021 April 3
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/atco13.c
+++ b/src/atco13.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraAtco13(double rc, double dc,
               double pr, double pd, double px, double rv,
@@ -20,7 +21,7 @@ int eraAtco13(double rc, double dc,
 **
 **  Given:
 **     rc,dc  double   ICRS right ascension at J2000.0 (radians, Note 1)
-**     pr     double   RA proper motion (radians/year; Note 2)
+**     pr     double   RA proper motion (radians/year, Note 2)
 **     pd     double   Dec proper motion (radians/year)
 **     px     double   parallax (arcsec)
 **     rv     double   radial velocity (km/s, +ve if receding)
@@ -151,7 +152,7 @@ int eraAtco13(double rc, double dc,
 **     eraAtciq     quick ICRS to CIRS
 **     eraAtioq     quick CIRS to observed
 **
-**  This revision:   2016 February 2
+**  This revision:   2021 April 3
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/atio13.c
+++ b/src/atio13.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraAtio13(double ri, double di,
               double utc1, double utc2, double dut1,
@@ -134,7 +135,7 @@ int eraAtio13(double ri, double di,
 **     eraApio13    astrometry parameters, CIRS-observed, 2013
 **     eraAtioq     quick CIRS to observed
 **
-**  This revision:   2016 February 2
+**  This revision:   2021 February 24
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/atoc13.c
+++ b/src/atoc13.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraAtoc13(const char *type, double ob1, double ob2,
               double utc1, double utc2, double dut1,
@@ -141,7 +142,7 @@ int eraAtoc13(const char *type, double ob1, double ob2,
 **     eraAtoiq     quick observed to CIRS
 **     eraAticq     quick CIRS to ICRS
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 February 24
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/atoi13.c
+++ b/src/atoi13.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraAtoi13(const char *type, double ob1, double ob2,
               double utc1, double utc2, double dut1,
@@ -140,7 +141,7 @@ int eraAtoi13(const char *type, double ob1, double ob2,
 **     eraApio13    astrometry parameters, CIRS-observed, 2013
 **     eraAtoiq     quick observed to CIRS
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 February 24
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/bi00.c
+++ b/src/bi00.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraBi00(double *dpsibi, double *depsbi, double *dra)
 /*
@@ -42,7 +43,7 @@ void eraBi00(double *dpsibi, double *depsbi, double *dra)
 **     2002.  The MHB2000 code itself was obtained on 2002 September 9
 **     from ftp://maia.usno.navy.mil/conv2000/chapter5/IAU2000A.
 **
-**  This revision:  2020 October 29
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -61,7 +62,7 @@ void eraBi00(double *dpsibi, double *depsbi, double *dra)
    *depsbi = DEBIAS;
    *dra = DRA0;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/bp00.c
+++ b/src/bp00.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraBp00(double date1, double date2,
              double rb[3][3], double rp[3][3], double rbp[3][3])
@@ -70,7 +71,7 @@ void eraBp00(double date1, double date2,
 **     n.b. The celestial ephemeris origin (CEO) was renamed "celestial
 **          intermediate origin" (CIO) by IAU 2006 Resolution 2.
 **
-**  This revision:  2013 August 21
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -116,7 +117,7 @@ void eraBp00(double date1, double date2,
 /* Bias-precession matrix: GCRS to mean of date. */
    eraRxr(rp, rbw, rbp);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/bp06.c
+++ b/src/bp06.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraBp06(double date1, double date2,
              double rb[3][3], double rp[3][3], double rbp[3][3])
@@ -64,7 +65,7 @@ void eraBp06(double date1, double date2,
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2013 August 21
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -87,7 +88,7 @@ void eraBp06(double date1, double date2,
 /* PxB matrix. */
    eraCr(rbpw, rbp);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/bpn2xy.c
+++ b/src/bpn2xy.c
@@ -34,7 +34,7 @@ void eraBpn2xy(double rbpn[3][3], double *x, double *y)
 **     n.b. The celestial ephemeris origin (CEO) was renamed "celestial
 **          intermediate origin" (CIO) by IAU 2006 Resolution 2.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -44,7 +44,7 @@ void eraBpn2xy(double rbpn[3][3], double *x, double *y)
    *x = rbpn[2][0];
    *y = rbpn[2][1];
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/c2i00a.c
+++ b/src/c2i00a.c
@@ -68,7 +68,7 @@ void eraC2i00a(double date1, double date2, double rc2i[3][3])
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2020 November 27
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -83,7 +83,7 @@ void eraC2i00a(double date1, double date2, double rc2i[3][3])
 /* Form the celestial-to-intermediate matrix. */
    eraC2ibpn(date1, date2, rbpn, rc2i);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/c2i00b.c
+++ b/src/c2i00b.c
@@ -68,7 +68,7 @@ void eraC2i00b(double date1, double date2, double rc2i[3][3])
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -83,7 +83,7 @@ void eraC2i00b(double date1, double date2, double rc2i[3][3])
 /* Form the celestial-to-intermediate matrix. */
    eraC2ibpn(date1, date2, rbpn, rc2i);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/c2i06a.c
+++ b/src/c2i06a.c
@@ -59,7 +59,7 @@ void eraC2i06a(double date1, double date2, double rc2i[3][3])
 **     McCarthy, D. D., Petit, G. (eds.), 2004, IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -80,7 +80,7 @@ void eraC2i06a(double date1, double date2, double rc2i[3][3])
 /* Form the celestial-to-intermediate matrix. */
    eraC2ixys(x, y, s, rc2i);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/c2ibpn.c
+++ b/src/c2ibpn.c
@@ -71,7 +71,7 @@ void eraC2ibpn(double date1, double date2, double rbpn[3][3],
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -86,7 +86,7 @@ void eraC2ibpn(double date1, double date2, double rbpn[3][3],
 /* Form the celestial-to-intermediate matrix (n.b. IAU 2000 specific). */
    eraC2ixy(date1, date2, x, y, rc2i);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/c2ixy.c
+++ b/src/c2ixy.c
@@ -65,7 +65,7 @@ void eraC2ixy(double date1, double date2, double x, double y,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -75,7 +75,7 @@ void eraC2ixy(double date1, double date2, double x, double y,
 /* Compute s and then the matrix. */
    eraC2ixys(x, y, eraS00(date1, date2, x, y), rc2i);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/c2ixys.c
+++ b/src/c2ixys.c
@@ -47,7 +47,7 @@ void eraC2ixys(double x, double y, double s, double rc2i[3][3])
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2014 November 7
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -67,7 +67,7 @@ void eraC2ixys(double x, double y, double s, double rc2i[3][3])
    eraRy(d, rc2i);
    eraRz(-(e+s), rc2i);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/c2s.c
+++ b/src/c2s.c
@@ -23,7 +23,7 @@ void eraC2s(double p[3], double *theta, double *phi)
 **
 **  3) At either pole, zero theta is returned.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -40,7 +40,7 @@ void eraC2s(double p[3], double *theta, double *phi)
    *theta = (d2 == 0.0) ? 0.0 : atan2(y, x);
    *phi = (z == 0.0) ? 0.0 : atan2(z, sqrt(d2));
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/c2t00b.c
+++ b/src/c2t00b.c
@@ -73,7 +73,7 @@ void eraC2t00b(double tta, double ttb, double uta, double utb,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2020 October 31
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -94,7 +94,7 @@ void eraC2t00b(double tta, double ttb, double uta, double utb,
 /* Combine to form the celestial-to-terrestrial matrix. */
    eraC2tcio(rc2i, era, rpom, rc2t);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/c2t06a.c
+++ b/src/c2t06a.c
@@ -72,7 +72,7 @@ void eraC2t06a(double tta, double ttb, double uta, double utb,
 **     McCarthy, D. D., Petit, G. (eds.), 2004, IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG
 **
-**  This revision:  2020 October 31
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -96,7 +96,7 @@ void eraC2t06a(double tta, double ttb, double uta, double utb,
 /* Combine to form the celestial-to-terrestrial matrix. */
    eraC2tcio(rc2i, era, rpom, rc2t);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/c2tcio.c
+++ b/src/c2tcio.c
@@ -52,7 +52,7 @@ void eraC2tcio(double rc2i[3][3], double era, double rpom[3][3],
 **     McCarthy, D. D., Petit, G. (eds.), 2004, IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG
 **
-**  This revision:  2013 August 24
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -66,7 +66,7 @@ void eraC2tcio(double rc2i[3][3], double era, double rpom[3][3],
    eraRz(era, r);
    eraRxr(rpom, r, rc2t);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/c2teqx.c
+++ b/src/c2teqx.c
@@ -52,7 +52,7 @@ void eraC2teqx(double rbpn[3][3], double gst, double rpom[3][3],
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 August 24
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -66,7 +66,7 @@ void eraC2teqx(double rbpn[3][3], double gst, double rpom[3][3],
    eraRz(gst, r);
    eraRxr(rpom, r, rc2t);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/c2tpe.c
+++ b/src/c2tpe.c
@@ -83,7 +83,7 @@ void eraC2tpe(double tta, double ttb, double uta, double utb,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2020 October 31
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -111,7 +111,7 @@ void eraC2tpe(double tta, double ttb, double uta, double utb,
 /* Combine to form the celestial-to-terrestrial matrix. */
    eraC2teqx(rbpn, gmst + ee, rpom, rc2t);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/c2txy.c
+++ b/src/c2txy.c
@@ -79,7 +79,7 @@ void eraC2txy(double tta, double ttb, double uta, double utb,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2020 October 31
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -103,7 +103,7 @@ void eraC2txy(double tta, double ttb, double uta, double utb,
 /* Combine to form the celestial-to-terrestrial matrix. */
    eraC2tcio(rc2i, era, rpom, rc2t);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/cal2jd.c
+++ b/src/cal2jd.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraCal2jd(int iy, int im, int id, double *djm0, double *djm)
 /*
@@ -43,7 +44,7 @@ int eraCal2jd(int iy, int im, int id, double *djm0, double *djm)
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 12.92 (p604).
 **
-**  This revision:  2013 August 7
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -84,6 +85,8 @@ int eraCal2jd(int iy, int im, int id, double *djm0, double *djm)
 
 /* Return status. */
    return j;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/cp.c
+++ b/src/cp.c
@@ -14,7 +14,7 @@ void eraCp(double p[3], double c[3])
 **  Returned:
 **     c        double[3]     copy
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -24,7 +24,7 @@ void eraCp(double p[3], double c[3])
    c[1] = p[1];
    c[2] = p[2];
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/cpv.c
+++ b/src/cpv.c
@@ -17,7 +17,7 @@ void eraCpv(double pv[2][3], double c[2][3])
 **  Called:
 **     eraCp        copy p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -26,7 +26,7 @@ void eraCpv(double pv[2][3], double c[2][3])
    eraCp(pv[0], c[0]);
    eraCp(pv[1], c[1]);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/cr.c
+++ b/src/cr.c
@@ -17,7 +17,7 @@ void eraCr(double r[3][3], double c[3][3])
 **  Called:
 **     eraCp        copy p-vector
 **
-**  This revision:  2016 May 19
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -27,7 +27,7 @@ void eraCr(double r[3][3], double c[3][3])
    eraCp(r[1], c[1]);
    eraCp(r[2], c[2]);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/d2dtf.c
+++ b/src/d2dtf.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 #include <string.h>
 
 int eraD2dtf(const char *scale, int ndp, double d1, double d2,
@@ -71,7 +72,7 @@ int eraD2dtf(const char *scale, int ndp, double d1, double d2,
 **     eraD2tf      decompose days to hms
 **     eraDat       delta(AT) = TAI-UTC
 **
-**  This revision:  2021 February 12
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -181,6 +182,8 @@ int eraD2dtf(const char *scale, int ndp, double d1, double d2,
 
 /* Status. */
    return js;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/d2tf.c
+++ b/src/d2tf.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraD2tf(int ndp, double days, char *sign, int ihmsf[4])
 /*
@@ -48,7 +49,7 @@ void eraD2tf(int ndp, double days, char *sign, int ihmsf[4])
 **     case where days is very nearly 1.0 and rounds up to 24 hours,
 **     by testing for ihmsf[0]=24 and setting ihmsf[0-3] to zero.
 **
-**  This revision:  2020 April 20
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -104,7 +105,7 @@ void eraD2tf(int ndp, double days, char *sign, int ihmsf[4])
    ihmsf[2] = (int) as;
    ihmsf[3] = (int) af;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/dat.c
+++ b/src/dat.c
@@ -116,14 +116,14 @@ int eraDat(int iy, int im, int id, double fd, double *deltat)
 **  Called:
 **     eraCal2jd    Gregorian calendar to JD
 **
-**  This revision:  2020 May 31
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
 /* Release year for this version of eraDat */
-   enum { IYV = 2020};
+   enum { IYV = 2021};
 
 /* Reference dates (MJD) and drift rates (s/day), pre leap seconds */
    static const double drift[][2] = {
@@ -246,6 +246,8 @@ int eraDat(int iy, int im, int id, double fd, double *deltat)
 
 /* Return the status. */
    return j;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/dtdb.c
+++ b/src/dtdb.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraDtdb(double date1, double date2,
                double ut, double elong, double u, double v)
@@ -157,7 +158,7 @@ double eraDtdb(double date1, double date2,
 **     Simon, J.L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G. & Laskar, J., Astron.Astrophys., 282, 663-683 (1994).
 **
-**  This revision:  2018 January 2
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -1158,6 +1159,8 @@ double eraDtdb(double date1, double date2,
    w = wt + wf + wj;
 
    return w;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/dtf2d.c
+++ b/src/dtf2d.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 #include <string.h>
 
 int eraDtf2d(const char *scale, int iy, int im, int id,
@@ -75,7 +76,7 @@ int eraDtf2d(const char *scale, int iy, int im, int id,
 **     eraDat       delta(AT) = TAI-UTC
 **     eraJd2cal    JD to Gregorian calendar
 **
-**  This revision:  2013 July 26
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -148,6 +149,8 @@ int eraDtf2d(const char *scale, int iy, int im, int id,
 
 /* Status. */
    return js;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/eceq06.c
+++ b/src/eceq06.c
@@ -53,7 +53,7 @@ void eraEceq06(double date1, double date2, double dl, double db,
 **     eraAnp       normalize angle into range 0 to 2pi
 **     eraAnpm      normalize angle into range +/- pi
 **
-**  This revision:  2016 February 9
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -77,6 +77,8 @@ void eraEceq06(double date1, double date2, double dl, double db,
 /* Express in conventional ranges. */
    *dr = eraAnp(a);
    *dd = eraAnpm(b);
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ecm06.c
+++ b/src/ecm06.c
@@ -59,7 +59,7 @@ void eraEcm06(double date1, double date2, double rm[3][3])
 **     eraRx        rotate around X-axis
 **     eraRxr       product of two r-matrices
 **
-**  This revision:  2015 December 11
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -80,6 +80,8 @@ void eraEcm06(double date1, double date2, double rm[3][3])
 
 /* ICRS to ecliptic coordinates rotation matrix, IAU 2006. */
    eraRxr(e, bp, rm);
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ee00.c
+++ b/src/ee00.c
@@ -60,7 +60,7 @@ double eraEe00(double date1, double date2, double epsa, double dpsi)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2008 May 16
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -73,6 +73,8 @@ double eraEe00(double date1, double date2, double epsa, double dpsi)
    ee = dpsi * cos(epsa) + eraEect00(date1, date2);
 
    return ee;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ee00a.c
+++ b/src/ee00a.c
@@ -58,7 +58,7 @@ double eraEe00a(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004).
 **
-**  This revision:  2008 May 16
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -80,6 +80,8 @@ double eraEe00a(double date1, double date2)
    ee = eraEe00(date1, date2, epsa, dpsi);
 
    return ee;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ee00b.c
+++ b/src/ee00b.c
@@ -64,7 +64,7 @@ double eraEe00b(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2020 November 3
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -86,6 +86,8 @@ double eraEe00b(double date1, double date2)
    ee = eraEe00(date1, date2, epsa, dpsi);
 
    return ee;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ee06a.c
+++ b/src/ee06a.c
@@ -50,7 +50,7 @@ double eraEe06a(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), 2004, IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG
 **
-**  This revision:  2008 May 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -67,6 +67,8 @@ double eraEe06a(double date1, double date2)
    ee  = eraAnpm(gst06a - gmst06);
 
    return ee;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/eect00.c
+++ b/src/eect00.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraEect00(double date1, double date2)
 /*
@@ -91,7 +92,7 @@ double eraEect00(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2019 June 23
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -227,6 +228,8 @@ double eraEect00(double date1, double date2)
    eect = (s0 + s1 * t ) * ERFA_DAS2R;
 
    return eect;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/eform.c
+++ b/src/eform.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraEform ( int n, double *a, double *f )
 /*
@@ -55,7 +56,7 @@ int eraEform ( int n, double *a, double *f )
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     p220.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -91,6 +92,8 @@ int eraEform ( int n, double *a, double *f )
 
 /* OK status. */
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/eo06a.c
+++ b/src/eo06a.c
@@ -54,7 +54,7 @@ double eraEo06a(double date1, double date2)
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2020 November 14
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -76,6 +76,8 @@ double eraEo06a(double date1, double date2)
    eo = eraEors(r, s);
 
    return eo;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/eors.c
+++ b/src/eors.c
@@ -33,7 +33,7 @@ double eraEors(double rnpb[3][3], double s)
 **
 **     Wallace, P. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2020 November 14
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -53,6 +53,8 @@ double eraEors(double rnpb[3][3], double s)
    eo = ((p != 0) || (q != 0)) ? s - atan2(q, p) : s;
 
    return eo;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/epb.c
+++ b/src/epb.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraEpb(double dj1, double dj2)
 /*
@@ -26,7 +27,7 @@ double eraEpb(double dj1, double dj2)
 **
 **     Lieske, J.H., 1979. Astron.Astrophys., 73, 282.
 **
-**  This revision:  2013 August 21
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -36,6 +37,8 @@ double eraEpb(double dj1, double dj2)
    const double D1900 = 36524.68648;
 
    return 1900.0 + ((dj1 - ERFA_DJ00) + (dj2 + D1900)) / ERFA_DTY;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/epb2jd.c
+++ b/src/epb2jd.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraEpb2jd(double epb, double *djm0, double *djm)
 /*
@@ -26,7 +27,7 @@ void eraEpb2jd(double epb, double *djm0, double *djm)
 **
 **     Lieske, J.H., 1979, Astron.Astrophys. 73, 282.
 **
-**  This revision:  2013 August 13
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -35,7 +36,7 @@ void eraEpb2jd(double epb, double *djm0, double *djm)
    *djm0 = ERFA_DJM0;
    *djm  =   15019.81352 + (epb - 1900.0) * ERFA_DTY;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/epj.c
+++ b/src/epj.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraEpj(double dj1, double dj2)
 /*
@@ -26,7 +27,7 @@ double eraEpj(double dj1, double dj2)
 **
 **     Lieske, J.H., 1979, Astron.Astrophys. 73, 282.
 **
-**  This revision:  2013 August 7
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -38,6 +39,8 @@ double eraEpj(double dj1, double dj2)
    epj = 2000.0 + ((dj1 - ERFA_DJ00) + dj2) / ERFA_DJY;
 
    return epj;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/epj2jd.c
+++ b/src/epj2jd.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraEpj2jd(double epj, double *djm0, double *djm)
 /*
@@ -26,7 +27,7 @@ void eraEpj2jd(double epj, double *djm0, double *djm)
 **
 **     Lieske, J.H., 1979, Astron.Astrophys. 73, 282.
 **
-**  This revision:  2013 August 7
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -35,7 +36,7 @@ void eraEpj2jd(double epj, double *djm0, double *djm)
    *djm0 = ERFA_DJM0;
    *djm  = ERFA_DJM00 + (epj - 2000.0) * 365.25;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/epv00.c
+++ b/src/epv00.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraEpv00(double date1, double date2,
              double pvh[2][3], double pvb[2][3])
@@ -94,7 +95,7 @@ int eraEpv00(double date1, double date2,
 **  5) It is permissible to use the same array for pvh and pvb, which
 **     will receive the barycentric values.
 **
-**  This revision:  2019 June 23
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -2534,6 +2535,8 @@ int eraEpv00(double date1, double date2,
 
 /* Return the status. */
    return jstat;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/eqec06.c
+++ b/src/eqec06.c
@@ -54,7 +54,7 @@ void eraEqec06(double date1, double date2, double dr, double dd,
 **     eraAnp       normalize angle into range 0 to 2pi
 **     eraAnpm      normalize angle into range +/- pi
 **
-**  This revision:  2016 February 9
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -78,6 +78,8 @@ void eraEqec06(double date1, double date2, double dr, double dd,
 /* Express in conventional ranges. */
    *dl = eraAnp(a);
    *db = eraAnpm(b);
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/eqeq94.c
+++ b/src/eqeq94.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraEqeq94(double date1, double date2)
 /*
@@ -51,7 +52,7 @@ double eraEqeq94(double date1, double date2)
 **     Capitaine, N. & Gontier, A.-M., 1993, Astron.Astrophys., 275,
 **     645-650.
 **
-**  This revision:  2017 October 12
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -77,6 +78,8 @@ double eraEqeq94(double date1, double date2)
    ee = dpsi*cos(eps0) + ERFA_DAS2R*(0.00264*sin(om) + 0.000063*sin(om+om));
 
    return ee;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/era00.c
+++ b/src/era00.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraEra00(double dj1, double dj2)
 /*
@@ -54,7 +55,7 @@ double eraEra00(double dj1, double dj2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -81,6 +82,8 @@ double eraEra00(double dj1, double dj2)
                             + 0.00273781191135448 * t));
 
    return theta;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/erfa.h
+++ b/src/erfa.h
@@ -12,12 +12,40 @@
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 
-#include "erfam.h"
 #include "math.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* Star-independent astrometry parameters */
+typedef struct {
+   double pmt;        /* PM time interval (SSB, Julian years) */
+   double eb[3];      /* SSB to observer (vector, au) */
+   double eh[3];      /* Sun to observer (unit vector) */
+   double em;         /* distance from Sun to observer (au) */
+   double v[3];       /* barycentric observer velocity (vector, c) */
+   double bm1;        /* sqrt(1-|v|^2): reciprocal of Lorenz factor */
+   double bpn[3][3];  /* bias-precession-nutation matrix */
+   double along;      /* longitude + s' + dERA(DUT) (radians) */
+   double phi;        /* geodetic latitude (radians) */
+   double xpl;        /* polar motion xp wrt local meridian (radians) */
+   double ypl;        /* polar motion yp wrt local meridian (radians) */
+   double sphi;       /* sine of geodetic latitude */
+   double cphi;       /* cosine of geodetic latitude */
+   double diurab;     /* magnitude of diurnal aberration vector */
+   double eral;       /* "local" Earth rotation angle (radians) */
+   double refa;       /* refraction constant A (radians) */
+   double refb;       /* refraction constant B (radians) */
+} eraASTROM;
+/* (Vectors eb, eh, em and v are all with respect to BCRS axes.) */
+
+/* Body parameters for light deflection */
+typedef struct {
+   double bm;         /* mass of the body (solar masses) */
+   double dl;         /* deflection limiter (radians^2/2) */
+   double pv[2][3];   /* barycentric PV of the body (au, au/day) */
+} eraLDBODY;
 
 /* Astronomy/Calendars */
 int eraCal2jd(int iy, int im, int id, double *djm0, double *djm);
@@ -68,6 +96,13 @@ int eraApio13(double utc1, double utc2, double dut1,
               double elong, double phi, double hm, double xp, double yp,
               double phpa, double tc, double rh, double wl,
               eraASTROM *astrom);
+void eraAtcc13(double rc, double dc,
+               double pr, double pd, double px, double rv,
+               double date1, double date2,
+               double *ra, double *da);
+void eraAtccq(double rc, double dc,
+              double pr, double pd, double px, double rv,
+              eraASTROM *astrom, double *ra, double *da);
 void eraAtci13(double rc, double dc,
                double pr, double pd, double px, double rv,
                double date1, double date2,
@@ -137,6 +172,7 @@ void eraRefco(double phpa, double tc, double rh, double wl,
 /* Astronomy/Ephemerides */
 int eraEpv00(double date1, double date2,
              double pvh[2][3], double pvb[2][3]);
+void eraMoon98(double date1, double date2, double pv[2][3]);
 int eraPlan94(double date1, double date2, int np, double pv[2][3]);
 
 /* Astronomy/FundamentalArgs */
@@ -491,15 +527,15 @@ void eraSxpv(double s, double pv[2][3], double spv[2][3]);
 
 
 /*----------------------------------------------------------------------
-**  
-**  
+**
+**
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  All rights reserved.
-**  
+**
 **  This library is derived, with permission, from the International
 **  Astronomical Union's "Standards of Fundamental Astronomy" library,
 **  available from http://www.iausofa.org.
-**  
+**
 **  The ERFA version is intended to retain identical functionality to
 **  the SOFA library, but made distinct through different function and
 **  file names, as set out in the SOFA license conditions.  The SOFA
@@ -508,36 +544,36 @@ void eraSxpv(double s, double pv[2][3], double spv[2][3]);
 **  state.  The ERFA version is not subject to this restriction and
 **  therefore can be included in distributions which do not support the
 **  concept of "read only" software.
-**  
+**
 **  Although the intent is to replicate the SOFA API (other than
 **  replacement of prefix names) and results (with the exception of
 **  bugs;  any that are discovered will be fixed), SOFA is not
 **  responsible for any errors found in this version of the library.
-**  
+**
 **  If you wish to acknowledge the SOFA heritage, please acknowledge
 **  that you are using a library derived from SOFA, rather than SOFA
 **  itself.
-**  
-**  
+**
+**
 **  TERMS AND CONDITIONS
-**  
+**
 **  Redistribution and use in source and binary forms, with or without
 **  modification, are permitted provided that the following conditions
 **  are met:
-**  
+**
 **  1 Redistributions of source code must retain the above copyright
 **    notice, this list of conditions and the following disclaimer.
-**  
+**
 **  2 Redistributions in binary form must reproduce the above copyright
 **    notice, this list of conditions and the following disclaimer in
 **    the documentation and/or other materials provided with the
 **    distribution.
-**  
+**
 **  3 Neither the name of the Standards Of Fundamental Astronomy Board,
 **    the International Astronomical Union nor the names of its
 **    contributors may be used to endorse or promote products derived
 **    from this software without specific prior written permission.
-**  
+**
 **  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 **  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 **  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -550,5 +586,5 @@ void eraSxpv(double s, double pv[2][3], double spv[2][3]);
 **  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 **  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 **  POSSIBILITY OF SUCH DAMAGE.
-**  
+**
 */

--- a/src/erfadatextra.h
+++ b/src/erfadatextra.h
@@ -6,6 +6,7 @@
 ** This file is NOT derived from SOFA sources.
 **
 */
+#include "erfaextra.h"
 
 /*
 **  Get the leap second table, initializing it to the built-in version

--- a/src/erfaextra.h
+++ b/src/erfaextra.h
@@ -9,19 +9,17 @@
 ** information, and for updating the leap second table.
 **
 ** The eraGetLeapSeconds and eraSetLeapSeconds functions are used as an
-** experimental interface for getting and setting the leap second table in
-** astropy 4.0.  They will be supported as long as astropy 4.0 is supported
-** (until 2021), but not necessarily beyond.  Comments and ideas about the
-** best way to keep the leap second tables up to date for all users of erfa
-** are welcome (https://github.com/liberfa/erfa).
+** experimental interface for getting and setting the leap second table
+** starting in astropy 4.0.  They will be supported as long as needed for
+** astropy.  Comments and ideas about the best way to keep the leap
+** second tables up to date for all users of erfa are welcome
+** (https://github.com/liberfa/erfa).
 **
 */
 
 
 #ifndef _ERFA_EXTRA_H
 #define _ERFA_EXTRA_H
-
-#include "erfam.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -67,6 +65,12 @@ const char* eraSofaVersion(void);
 /*
 ** Get and set leap seconds (not supported by SOFA; EXPERIMENTAL)
 */
+
+typedef struct {
+   int iyear, month;
+   double delat;
+} eraLEAPSECOND;
+
 int eraGetLeapSeconds(eraLEAPSECOND **leapseconds);
 void eraSetLeapSeconds(eraLEAPSECOND *leapseconds, int count);
 

--- a/src/erfam.h
+++ b/src/erfam.h
@@ -12,41 +12,6 @@
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 
-/* Star-independent astrometry parameters */
-typedef struct {
-   double pmt;        /* PM time interval (SSB, Julian years) */
-   double eb[3];      /* SSB to observer (vector, au) */
-   double eh[3];      /* Sun to observer (unit vector) */
-   double em;         /* distance from Sun to observer (au) */
-   double v[3];       /* barycentric observer velocity (vector, c) */
-   double bm1;        /* sqrt(1-|v|^2): reciprocal of Lorenz factor */
-   double bpn[3][3];  /* bias-precession-nutation matrix */
-   double along;      /* longitude + s' + dERA(DUT) (radians) */
-   double phi;        /* geodetic latitude (radians) */
-   double xpl;        /* polar motion xp wrt local meridian (radians) */
-   double ypl;        /* polar motion yp wrt local meridian (radians) */
-   double sphi;       /* sine of geodetic latitude */
-   double cphi;       /* cosine of geodetic latitude */
-   double diurab;     /* magnitude of diurnal aberration vector */
-   double eral;       /* "local" Earth rotation angle (radians) */
-   double refa;       /* refraction constant A (radians) */
-   double refb;       /* refraction constant B (radians) */
-} eraASTROM;
-/* (Vectors eb, eh, em and v are all with respect to BCRS axes.) */
-
-/* Body parameters for light deflection */
-typedef struct {
-   double bm;         /* mass of the body (solar masses) */
-   double dl;         /* deflection limiter (radians^2/2) */
-   double pv[2][3];   /* barycentric PV of the body (au, au/day) */
-} eraLDBODY;
-
-/* Leap second definition */
-typedef struct {
-   int iyear, month;
-   double delat;
-} eraLEAPSECOND;
-
 /* Pi */
 #define ERFA_DPI (3.141592653589793238462643)
 
@@ -152,15 +117,15 @@ typedef struct {
 
 
 /*----------------------------------------------------------------------
-**
-**
+**  
+**  
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  All rights reserved.
-**
+**  
 **  This library is derived, with permission, from the International
 **  Astronomical Union's "Standards of Fundamental Astronomy" library,
 **  available from http://www.iausofa.org.
-**
+**  
 **  The ERFA version is intended to retain identical functionality to
 **  the SOFA library, but made distinct through different function and
 **  file names, as set out in the SOFA license conditions.  The SOFA
@@ -169,36 +134,36 @@ typedef struct {
 **  state.  The ERFA version is not subject to this restriction and
 **  therefore can be included in distributions which do not support the
 **  concept of "read only" software.
-**
+**  
 **  Although the intent is to replicate the SOFA API (other than
 **  replacement of prefix names) and results (with the exception of
 **  bugs;  any that are discovered will be fixed), SOFA is not
 **  responsible for any errors found in this version of the library.
-**
+**  
 **  If you wish to acknowledge the SOFA heritage, please acknowledge
 **  that you are using a library derived from SOFA, rather than SOFA
 **  itself.
-**
-**
+**  
+**  
 **  TERMS AND CONDITIONS
-**
+**  
 **  Redistribution and use in source and binary forms, with or without
 **  modification, are permitted provided that the following conditions
 **  are met:
-**
+**  
 **  1 Redistributions of source code must retain the above copyright
 **    notice, this list of conditions and the following disclaimer.
-**
+**  
 **  2 Redistributions in binary form must reproduce the above copyright
 **    notice, this list of conditions and the following disclaimer in
 **    the documentation and/or other materials provided with the
 **    distribution.
-**
+**  
 **  3 Neither the name of the Standards Of Fundamental Astronomy Board,
 **    the International Astronomical Union nor the names of its
 **    contributors may be used to endorse or promote products derived
 **    from this software without specific prior written permission.
-**
+**  
 **  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 **  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 **  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -211,5 +176,5 @@ typedef struct {
 **  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 **  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 **  POSSIBILITY OF SUCH DAMAGE.
-**
+**  
 */

--- a/src/fad03.c
+++ b/src/fad03.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraFad03(double t)
 /*
@@ -31,7 +32,7 @@ double eraFad03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -48,6 +49,8 @@ double eraFad03(double t)
              t * (        - 0.00003169 ) ) ) ), ERFA_TURNAS ) * ERFA_DAS2R;
 
    return a;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/fae03.c
+++ b/src/fae03.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraFae03(double t)
 /*
@@ -34,7 +35,7 @@ double eraFae03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -47,6 +48,8 @@ double eraFae03(double t)
    a = fmod(1.753470314 + 628.3075849991 * t, ERFA_D2PI);
 
    return a;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/faf03.c
+++ b/src/faf03.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraFaf03(double t)
 /*
@@ -32,7 +33,7 @@ double eraFaf03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -51,6 +52,7 @@ double eraFaf03(double t)
 
    return a;
 
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/faju03.c
+++ b/src/faju03.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraFaju03(double t)
 /*
@@ -34,7 +35,7 @@ double eraFaju03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -47,6 +48,8 @@ double eraFaju03(double t)
    a = fmod(0.599546497 + 52.9690962641 * t, ERFA_D2PI);
 
    return a;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/fal03.c
+++ b/src/fal03.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraFal03(double t)
 /*
@@ -31,7 +32,7 @@ double eraFal03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -48,6 +49,8 @@ double eraFal03(double t)
              t * (        - 0.00024470 ) ) ) ), ERFA_TURNAS ) * ERFA_DAS2R;
 
    return a;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/falp03.c
+++ b/src/falp03.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraFalp03(double t)
 /*
@@ -31,7 +32,7 @@ double eraFalp03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -48,6 +49,8 @@ double eraFalp03(double t)
              t * (       - 0.00001149 ) ) ) ), ERFA_TURNAS ) * ERFA_DAS2R;
 
    return a;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/fama03.c
+++ b/src/fama03.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraFama03(double t)
 /*
@@ -34,7 +35,7 @@ double eraFama03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -47,6 +48,8 @@ double eraFama03(double t)
    a = fmod(6.203480913 + 334.0612426700 * t, ERFA_D2PI);
 
    return a;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/fame03.c
+++ b/src/fame03.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraFame03(double t)
 /*
@@ -34,7 +35,7 @@ double eraFame03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -47,6 +48,8 @@ double eraFame03(double t)
    a = fmod(4.402608842 + 2608.7903141574 * t, ERFA_D2PI);
 
    return a;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/fane03.c
+++ b/src/fane03.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraFane03(double t)
 /*
@@ -31,7 +32,7 @@ double eraFane03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -44,6 +45,8 @@ double eraFane03(double t)
    a = fmod(5.311886287 + 3.8133035638 * t, ERFA_D2PI);
 
    return a;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/faom03.c
+++ b/src/faom03.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraFaom03(double t)
 /*
@@ -31,7 +32,7 @@ double eraFaom03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J., 1994, Astron.Astrophys. 282, 663-683.
 **
-**  This revision:  2020 November 16
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -49,6 +50,8 @@ double eraFaom03(double t)
              t * (       - 0.00005939 ) ) ) ), ERFA_TURNAS ) * ERFA_DAS2R;
 
    return a;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/fapa03.c
+++ b/src/fapa03.c
@@ -35,7 +35,7 @@ double eraFapa03(double t)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -48,6 +48,8 @@ double eraFapa03(double t)
    a = (0.024381750 + 0.00000538691 * t) * t;
 
    return a;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/fasa03.c
+++ b/src/fasa03.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraFasa03(double t)
 /*
@@ -34,7 +35,7 @@ double eraFasa03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -47,6 +48,8 @@ double eraFasa03(double t)
    a = fmod(0.874016757 + 21.3299104960 * t, ERFA_D2PI);
 
    return a;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/faur03.c
+++ b/src/faur03.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraFaur03(double t)
 /*
@@ -31,7 +32,7 @@ double eraFaur03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -44,6 +45,8 @@ double eraFaur03(double t)
    a = fmod(5.481293872 + 7.4781598567 * t, ERFA_D2PI);
 
    return a;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/fave03.c
+++ b/src/fave03.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraFave03(double t)
 /*
@@ -34,7 +35,7 @@ double eraFave03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -47,6 +48,8 @@ double eraFave03(double t)
    a = fmod(3.176146697 + 1021.3285546211 * t, ERFA_D2PI);
 
    return a;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/fk425.c
+++ b/src/fk425.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraFk425(double r1950, double d1950,
               double dr1950, double dd1950,
@@ -110,7 +111,7 @@ void eraFk425(double r1950, double d1950,
 **     from FK4 B1950.0 to FK5 J2000.0 using matrices in 6-space".
 **     Astron.J. 97, 274.
 **
-**  This revision:   2018 December 5
+**  This revision:   2021 February 24
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/fk45z.c
+++ b/src/fk45z.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraFk45z(double r1950, double d1950, double bepoch,
               double *r2000, double *d2000)
@@ -78,7 +79,7 @@ void eraFk45z(double r1950, double d1950, double bepoch,
 **     eraPvu       update a pv-vector
 **     eraS2c       spherical to p-vector
 **
-**  This revision:   2020 November 19
+**  This revision:   2021 February 24
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/fk524.c
+++ b/src/fk524.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraFk524(double r2000, double d2000,
               double dr2000, double dd2000,
@@ -104,7 +105,7 @@ void eraFk524(double r2000, double d2000,
 **     from FK4 B1950.0 to FK5 J2000.0 using matrices in 6-space".
 **     Astron.J. 97, 274.
 **
-**  This revision:   2019 October 3
+**  This revision:   2021 February 24
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/fk52h.c
+++ b/src/fk52h.c
@@ -53,7 +53,7 @@ void eraFk52h(double r5, double d5,
 **
 **     F.Mignard & M.Froeschle, Astron.Astrophys., 354, 732-739 (2000).
 **
-**  This revision:  2017 October 12
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -87,7 +87,7 @@ void eraFk52h(double r5, double d5,
 /* Hipparcos pv-vector to spherical. */
    eraPvstar(pvh, rh, dh, drh, ddh, pxh, rvh);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/fk5hip.c
+++ b/src/fk5hip.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraFk5hip(double r5h[3][3], double s5h[3])
 /*
@@ -36,7 +37,7 @@ void eraFk5hip(double r5h[3][3], double s5h[3])
 **
 **     F.Mignard & M.Froeschle, Astron.Astrophys., 354, 732-739 (2000).
 **
-**  This revision:  2017 October 12
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -70,7 +71,7 @@ void eraFk5hip(double r5h[3][3], double s5h[3])
    s5h[1] = omy;
    s5h[2] = omz;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/fk5hz.c
+++ b/src/fk5hz.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraFk5hz(double r5, double d5, double date1, double date2,
               double *rh, double *dh)
@@ -69,7 +70,7 @@ void eraFk5hz(double r5, double d5, double date1, double date2,
 **
 **     F.Mignard & M.Froeschle, 2000, Astron.Astrophys. 354, 732-739.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -104,7 +105,7 @@ void eraFk5hz(double r5, double d5, double date1, double date2,
    eraC2s(ph, &w, dh);
    *rh = eraAnp(w);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/fw2m.c
+++ b/src/fw2m.c
@@ -70,7 +70,7 @@ void eraFw2m(double gamb, double phib, double psi, double eps,
 **
 **     Hilton, J. et al., 2006, Celest.Mech.Dyn.Astron. 94, 351
 **
-**  This revision:  2020 November 17
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -83,7 +83,7 @@ void eraFw2m(double gamb, double phib, double psi, double eps,
    eraRz(-psi, r);
    eraRx(-eps, r);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/fw2xy.c
+++ b/src/fw2xy.c
@@ -50,7 +50,7 @@ void eraFw2xy(double gamb, double phib, double psi, double eps,
 **
 **     Hilton, J. et al., 2006, Celest.Mech.Dyn.Astron. 94, 351
 **
-**  This revision:  2013 September 2
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -65,7 +65,7 @@ void eraFw2xy(double gamb, double phib, double psi, double eps,
 /* Extract CIP X,Y. */
    eraBpn2xy(r, x, y);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/g2icrs.c
+++ b/src/g2icrs.c
@@ -1,3 +1,4 @@
+
 #include "erfa.h"
 
 void eraG2icrs ( double dl, double db, double *dr, double *dd )
@@ -61,7 +62,7 @@ void eraG2icrs ( double dl, double db, double *dr, double *dd )
 **     derived from the ESA Hipparcos Space Astrometry Mission.  ESA
 **     Publications Division, Noordwijk, Netherlands.
 **
-**  This revision:   2018 January 2
+**  This revision:   2021 January 25
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -75,8 +76,8 @@ void eraG2icrs ( double dl, double db, double *dr, double *dd )
 **
 **  P = 192.85948    right ascension of the Galactic north pole in ICRS
 **  Q =  27.12825    declination of the Galactic north pole in ICRS
-**  R =  32.93192    longitude of the ascending node of the Galactic
-**                   plane on the ICRS equator
+**  R =  32.93192    Galactic longitude of the ascending node of
+**                   the Galactic equator on the ICRS equator
 **
 **  ICRS to galactic rotation matrix, obtained by computing
 **  R_3(-R) R_1(pi/2-Q) R_3(pi/2+P) to the full precision shown:

--- a/src/gc2gd.c
+++ b/src/gc2gd.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraGc2gd ( int n, double xyz[3],
                double *elong, double *phi, double *height )
@@ -51,7 +52,7 @@ int eraGc2gd ( int n, double xyz[3],
 **     eraEform     Earth reference ellipsoids
 **     eraGc2gde    geocentric to geodetic transformation, general
 **
-**  This revision:  2013 September 1
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -79,6 +80,8 @@ int eraGc2gd ( int n, double xyz[3],
 
 /* Return the status. */
    return j;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/gc2gde.c
+++ b/src/gc2gde.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraGc2gde ( double a, double f, double xyz[3],
                 double *elong, double *phi, double *height )
@@ -56,7 +57,7 @@ int eraGc2gde ( double a, double f, double xyz[3],
 **     coordinates accelerated by Halley's method", J.Geodesy (2006)
 **     79: 689-693
 **
-**  This revision:  2014 November 7
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -144,6 +145,8 @@ int eraGc2gde ( double a, double f, double xyz[3],
 
 /* OK status. */
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/gd2gc.c
+++ b/src/gd2gc.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraGd2gc ( int n, double elong, double phi, double height,
                double xyz[3] )
@@ -54,7 +55,7 @@ int eraGd2gc ( int n, double elong, double phi, double height,
 **     eraGd2gce    geodetic to geocentric transformation, general
 **     eraZp        zero p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -78,6 +79,8 @@ int eraGd2gc ( int n, double elong, double phi, double height,
 
 /* Return the status. */
    return j;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/gd2gce.c
+++ b/src/gd2gce.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraGd2gce ( double a, double f, double elong, double phi,
                 double height, double xyz[3] )
@@ -55,7 +56,7 @@ int eraGd2gce ( double a, double f, double elong, double phi,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 4.22, p202.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -82,6 +83,8 @@ int eraGd2gce ( double a, double f, double elong, double phi,
 
 /* Success. */
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/gmst00.c
+++ b/src/gmst00.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraGmst00(double uta, double utb, double tta, double ttb)
 /*
@@ -68,7 +69,7 @@ double eraGmst00(double uta, double utb, double tta, double ttb)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2020 November 17
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -90,6 +91,8 @@ double eraGmst00(double uta, double utb, double tta, double ttb)
           * t) * t) * t) * t) * ERFA_DAS2R);
 
    return gmst;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/gmst06.c
+++ b/src/gmst06.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraGmst06(double uta, double utb, double tta, double ttb)
 /*
@@ -58,7 +59,7 @@ double eraGmst06(double uta, double utb, double tta, double ttb)
 **     Capitaine, N., Wallace, P.T. & Chapront, J., 2005,
 **     Astron.Astrophys. 432, 355
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -81,6 +82,8 @@ double eraGmst06(double uta, double utb, double tta, double ttb)
           * t) * t) * t) * t) * t) * ERFA_DAS2R);
 
    return gmst;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/gmst82.c
+++ b/src/gmst82.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraGmst82(double dj1, double dj2)
 /*
@@ -60,7 +61,7 @@ double eraGmst82(double dj1, double dj2)
 **
 **     Aoki et al., Astron.Astrophys., 105, 359-361 (1982).
 **
-**  This revision:  2020 January 12
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -95,6 +96,8 @@ double eraGmst82(double dj1, double dj2)
    gmst = eraAnp(ERFA_DS2R * ((A + (B + (C + D * t) * t) * t) + f));
 
    return gmst;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/gst00a.c
+++ b/src/gst00a.c
@@ -69,7 +69,7 @@ double eraGst00a(double uta, double utb, double tta, double ttb)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2020 November 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -83,6 +83,8 @@ double eraGst00a(double uta, double utb, double tta, double ttb)
    gst = eraAnp(gmst00 + ee00a);
 
    return gst;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/gst00b.c
+++ b/src/gst00b.c
@@ -77,7 +77,7 @@ double eraGst00b(double uta, double utb)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2020 November 19
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -91,6 +91,8 @@ double eraGst00b(double uta, double utb)
    gst = eraAnp(gmst00 + ee00b);
 
    return gst;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/gst06.c
+++ b/src/gst06.c
@@ -64,7 +64,7 @@ double eraGst06(double uta, double utb, double tta, double ttb,
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2020 November 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -85,6 +85,8 @@ double eraGst06(double uta, double utb, double tta, double ttb,
    gst = eraAnp(era - eors);
 
    return gst;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/gst06a.c
+++ b/src/gst06a.c
@@ -60,7 +60,7 @@ double eraGst06a(double uta, double utb, double tta, double ttb)
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2020 November 20
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -76,6 +76,8 @@ double eraGst06a(double uta, double utb, double tta, double ttb)
    gst = eraGst06(uta, utb, tta, ttb, rnpb);
 
    return gst;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/gst94.c
+++ b/src/gst94.c
@@ -62,7 +62,7 @@ double eraGst94(double uta, double utb)
 **
 **     IAU Resolution C7, Recommendation 3 (1994)
 **
-**  This revision:  2020 November 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -76,6 +76,8 @@ double eraGst94(double uta, double utb)
    gst = eraAnp(gmst82  + eqeq94);
 
    return gst;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/h2fk5.c
+++ b/src/h2fk5.c
@@ -55,7 +55,7 @@ void eraH2fk5(double rh, double dh,
 **
 **     F.Mignard & M.Froeschle, Astron.Astrophys., 354, 732-739 (2000).
 **
-**  This revision:  2017 October 12
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -92,7 +92,7 @@ void eraH2fk5(double rh, double dh,
 /* FK5 pv-vector to spherical. */
    eraPvstar(pv5, r5, d5, dr5, dd5, px5, rv5);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/hd2ae.c
+++ b/src/hd2ae.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraHd2ae (double ha, double dec, double phi,
                double *az, double *el)
@@ -56,9 +57,9 @@ void eraHd2ae (double ha, double dec, double phi,
 **  7)  Again for efficiency, no range checking of arguments is carried
 **      out.
 **
-**  Last revision:   2017 September 12
+**  Last revision:   2021 February 24
 **
-**  ERFA release 2021-01-25
+**  ERFA release 2021-05-12
 **
 **  Copyright (C) 2021 IAU ERFA Board.  See notes at end.
 */

--- a/src/hd2pa.c
+++ b/src/hd2pa.c
@@ -46,7 +46,7 @@ double eraHd2pa (double ha, double dec, double phi)
 **
 **  Last revision:   2017 September 12
 **
-**  ERFA release 2021-01-25
+**  ERFA release 2021-05-12
 **
 **  Copyright (C) 2021 IAU ERFA Board.  See notes at end.
 */

--- a/src/hfk5z.c
+++ b/src/hfk5z.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraHfk5z(double rh, double dh, double date1, double date2,
               double *r5, double *d5, double *dr5, double *dd5)
@@ -74,7 +75,7 @@ void eraHfk5z(double rh, double dh, double date1, double date2,
 **
 **     F.Mignard & M.Froeschle, 2000, Astron.Astrophys. 354, 732-739.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -119,7 +120,7 @@ void eraHfk5z(double rh, double dh, double date1, double date2,
    eraPv2s(pv5e, &w, d5, &r, dr5, dd5, &v);
    *r5 = eraAnp(w);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/icrs2g.c
+++ b/src/icrs2g.c
@@ -61,7 +61,7 @@ void eraIcrs2g ( double dr, double dd, double *dl, double *db )
 **     derived from the ESA Hipparcos Space Astrometry Mission.  ESA
 **     Publications Division, Noordwijk, Netherlands.
 **
-**  This revision:   2018 January 2
+**  This revision:   2021 January 25
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -75,8 +75,8 @@ void eraIcrs2g ( double dr, double dd, double *dl, double *db )
 **
 **  P = 192.85948    right ascension of the Galactic north pole in ICRS
 **  Q =  27.12825    declination of the Galactic north pole in ICRS
-**  R =  32.93192    longitude of the ascending node of the Galactic
-**                   plane on the ICRS equator
+**  R =  32.93192    Galactic longitude of the ascending node of
+**                   the Galactic equator on the ICRS equator
 **
 **  ICRS to galactic rotation matrix, obtained by computing
 **  R_3(-R) R_1(pi/2-Q) R_3(pi/2+P) to the full precision shown:

--- a/src/ir.c
+++ b/src/ir.c
@@ -11,7 +11,7 @@ void eraIr(double r[3][3])
 **  Returned:
 **     r       double[3][3]    r-matrix
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -27,7 +27,7 @@ void eraIr(double r[3][3])
    r[2][1] = 0.0;
    r[2][2] = 1.0;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/jd2cal.c
+++ b/src/jd2cal.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 #include <float.h>
 
 int eraJd2cal(double dj1, double dj2,
@@ -58,7 +59,7 @@ int eraJd2cal(double dj1, double dj2,
 **     Klein, A., A Generalized Kahan-Babuska-Summation-Algorithm.
 **     Computing, 76, 279-293 (2006), Section 3.
 **
-**  This revision:  2020 October 21
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -141,7 +142,10 @@ int eraJd2cal(double dj1, double dj2,
    *iy = (int) (100L * (n - 49L) + i + l);
    *fd = f;
 
+/* Success. */
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/jdcalf.c
+++ b/src/jdcalf.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraJdcalf(int ndp, double dj1, double dj2, int iymdf[4])
 /*
@@ -56,7 +57,7 @@ int eraJdcalf(int ndp, double dj1, double dj2, int iymdf[4])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 12.92 (p604).
 **
-**  This revision:  2020 October 22
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -118,6 +119,8 @@ int eraJdcalf(int ndp, double dj1, double dj2, int iymdf[4])
 
 /* Return the status. */
    return j;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ld.c
+++ b/src/ld.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraLd(double bm, double p[3], double q[3], double e[3],
            double em, double dlim, double p1[3])
@@ -68,7 +69,7 @@ void eraLd(double bm, double p[3], double q[3], double e[3],
 **     eraPdp       scalar product of two p-vectors
 **     eraPxp       vector product of two p-vectors
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 February 24
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/ldn.c
+++ b/src/ldn.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraLdn(int n, eraLDBODY b[], double ob[3], double sc[3],
             double sn[3])
@@ -78,7 +79,7 @@ void eraLdn(int n, eraLDBODY b[], double ob[3], double sc[3],
 **     eraPn        decompose p-vector into modulus and direction
 **     eraLd        light deflection by a solar-system body
 **
-**  This revision:   2017 March 16
+**  This revision:   2021 February 24
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/lteceq.c
+++ b/src/lteceq.c
@@ -50,7 +50,7 @@ void eraLteceq(double epj, double dl, double db, double *dr, double *dd)
 **    expressions, valid for long time intervals (Corrigendum),
 **    Astron.Astrophys. 541, C1
 **
-**  This revision:  2016 February 9
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -74,6 +74,8 @@ void eraLteceq(double epj, double dl, double db, double *dr, double *dd)
 /* Express in conventional ranges. */
    *dr = eraAnp(a);
    *dd = eraAnpm(b);
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ltecm.c
+++ b/src/ltecm.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraLtecm(double epj, double rm[3][3])
 /*
@@ -56,7 +57,7 @@ void eraLtecm(double epj, double rm[3][3])
 **    expressions, valid for long time intervals (Corrigendum),
 **    Astron.Astrophys. 541, C1
 **
-**  This revision:  2015 December 6
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -93,6 +94,8 @@ void eraLtecm(double epj, double rm[3][3])
    rm[2][0] =   z[0]    - z[1]*dr + z[2]*dx;
    rm[2][1] =   z[0]*dr + z[1]    + z[2]*de;
    rm[2][2] = - z[0]*dx - z[1]*de + z[2];
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/lteqec.c
+++ b/src/lteqec.c
@@ -51,7 +51,7 @@ void eraLteqec(double epj, double dr, double dd, double *dl, double *db)
 **    expressions, valid for long time intervals (Corrigendum),
 **    Astron.Astrophys. 541, C1
 **
-**  This revision:  2016 February 9
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -75,6 +75,8 @@ void eraLteqec(double epj, double dr, double dd, double *dl, double *db)
 /* Express in conventional ranges. */
    *dl = eraAnp(a);
    *db = eraAnpm(b);
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ltp.c
+++ b/src/ltp.c
@@ -47,7 +47,7 @@ void eraLtp(double epj, double rp[3][3])
 **    expressions, valid for long time intervals (Corrigendum),
 **    Astron.Astrophys. 541, C1
 **
-**  This revision:  2015 December 6
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -76,6 +76,8 @@ void eraLtp(double epj, double rp[3][3])
       rp[1][i] = v[i];
       rp[2][i] = peqr[i];
    }
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ltpb.c
+++ b/src/ltpb.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraLtpb(double epj, double rpb[3][3])
 /*
@@ -45,7 +46,7 @@ void eraLtpb(double epj, double rpb[3][3])
 **    expressions, valid for long time intervals (Corrigendum),
 **    Astron.Astrophys. 541, C1
 **
-**  This revision:  2015 December 6
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -69,6 +70,8 @@ void eraLtpb(double epj, double rpb[3][3])
       rpb[i][1] =  rp[i][0]*dr + rp[i][1]    + rp[i][2]*de;
       rpb[i][2] = -rp[i][0]*dx - rp[i][1]*de + rp[i][2];
    }
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ltpecl.c
+++ b/src/ltpecl.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraLtpecl(double epj, double vec[3])
 /*
@@ -36,7 +37,7 @@ void eraLtpecl(double epj, double vec[3])
 **    expressions, valid for long time intervals (Corrigendum),
 **    Astron.Astrophys. 541, C1
 **
-**  This revision:  2016 February 9
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -113,6 +114,8 @@ void eraLtpecl(double epj, double vec[3])
    vec[0] = p;
    vec[1] = - q*c - w*s;
    vec[2] = - q*s + w*c;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ltpequ.c
+++ b/src/ltpequ.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraLtpequ(double epj, double veq[3])
 /*
@@ -36,7 +37,7 @@ void eraLtpequ(double epj, double veq[3])
 **    expressions, valid for long time intervals (Corrigendum),
 **    Astron.Astrophys. 541, C1
 **
-**  This revision:  2016 February 9
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -113,6 +114,8 @@ void eraLtpequ(double epj, double veq[3])
    veq[1] = y;
    w = 1.0 - x*x - y*y;
    veq[2] = w < 0.0 ? 0.0 : sqrt(w);
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/moon98.c
+++ b/src/moon98.c
@@ -1,0 +1,615 @@
+#include "erfa.h"
+#include "erfam.h"
+#include <stdlib.h>
+
+void eraMoon98 ( double date1, double date2, double pv[2][3] )
+/*
+**  - - - - - - - - - -
+**   e r a M o o n 9 8
+**  - - - - - - - - - -
+**
+**  Approximate geocentric position and velocity of the Moon.
+**
+**  n.b. Not IAU-endorsed and without canonical status.
+**
+**  Given:
+**     date1  double         TT date part A (Notes 1,4)
+**     date2  double         TT date part B (Notes 1,4)
+**
+**  Returned:
+**     pv     double[2][3]   Moon p,v, GCRS (AU, AU/d, Note 5)
+**
+**  Notes:
+**
+**  1) The TT date date1+date2 is a Julian Date, apportioned in any
+**     convenient way between the two arguments.  For example,
+**     JD(TT)=2450123.7 could be expressed in any of these ways, among
+**     others:
+**
+**            date1          date2
+**
+**         2450123.7           0.0       (JD method)
+**         2451545.0       -1421.3       (J2000 method)
+**         2400000.5       50123.2       (MJD method)
+**         2450123.5           0.2       (date & time method)
+**
+**     The JD method is the most natural and convenient to use in cases
+**     where the loss of several decimal digits of resolution is
+**     acceptable.  The J2000 method is best matched to the way the
+**     argument is handled internally and will deliver the optimum
+**     resolution.  The MJD method and the date & time methods are both
+**     good compromises between resolution and convenience.  The limited
+**     accuracy of the present algorithm is such that any of the methods
+**     is satisfactory.
+**
+**  2) This function is a full implementation of the algorithm
+**     published by Meeus (see reference) except that the light-time
+**     correction to the Moon's mean longitude has been omitted.
+**
+**  3) Comparisons with ELP/MPP02 over the interval 1950-2100 gave RMS
+**     errors of 2.9 arcsec in geocentric direction, 6.1 km in position
+**     and 36 mm/s in velocity.  The worst case errors were 18.3 arcsec
+**     in geocentric direction, 31.7 km in position and 172 mm/s in
+**     velocity.
+**
+**  4) The original algorithm is expressed in terms of "dynamical time",
+**     which can either be TDB or TT without any significant change in
+**     accuracy.  UT cannot be used without incurring significant errors
+**     (30 arcsec in the present era) due to the Moon's 0.5 arcsec/sec
+**     movement.
+**
+**  5) The result is with respect to the GCRS (the same as J2000.0 mean
+**     equator and equinox to within 23 mas).
+**
+**  6) Velocity is obtained by a complete analytical differentiation
+**     of the Meeus model.
+**
+**  7) The Meeus algorithm generates position and velocity in mean
+**     ecliptic coordinates of date, which the present function then
+**     rotates into GCRS.  Because the ecliptic system is precessing,
+**     there is a coupling between this spin (about 1.4 degrees per
+**     century) and the Moon position that produces a small velocity
+**     contribution.  In the present function this effect is neglected
+**     as it corresponds to a maximum difference of less than 3 mm/s and
+**     increases the RMS error by only 0.4%.
+**
+**  References:
+**
+**     Meeus, J., Astronomical Algorithms, 2nd edition, Willmann-Bell,
+**     1998, p337.
+**
+**     Simon, J.L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
+**     Francou, G. & Laskar, J., Astron.Astrophys., 1994, 282, 663
+**
+**  Defined in erfam.h:
+**     ERFA_DAU           astronomical unit (m)
+**     ERFA_DJC           days per Julian century
+**     ERFA_DJ00          reference epoch (J2000.0), Julian Date
+**     ERFA_DD2R          degrees to radians
+**
+**  Called:
+**     eraS2pv      spherical coordinates to pv-vector
+**     eraPfw06     bias-precession F-W angles, IAU 2006
+**     eraIr        initialize r-matrix to identity
+**     eraRz        rotate around Z-axis
+**     eraRx        rotate around X-axis
+**     eraRxpv      product of r-matrix and pv-vector
+**
+**  This revision:  2021 May 11
+**
+**  Copyright (C) 2013-2021, NumFOCUS Foundation.
+**  Derived, with permission, from the SOFA library.  See notes at end of file.
+*/
+{
+/*
+**  Coefficients for fundamental arguments:
+**
+**  . Powers of time in Julian centuries
+**  . Units are degrees.
+*/
+
+/* Moon's mean longitude (wrt mean equinox and ecliptic of date) */
+   static double elp0 = 218.31665436,        /* Simon et al. (1994). */
+                 elp1 = 481267.88123421,
+                 elp2 = -0.0015786,
+                 elp3 = 1.0 / 538841.0,
+                 elp4 = -1.0 / 65194000.0;
+   double elp, delp;
+
+/* Moon's mean elongation */
+   static double d0 = 297.8501921,
+                 d1 = 445267.1114034,
+                 d2 = -0.0018819,
+                 d3 = 1.0 / 545868.0,
+                 d4 = 1.0 / 113065000.0;
+   double d, dd;
+
+/* Sun's mean anomaly */
+   static double em0 = 357.5291092,
+                 em1 = 35999.0502909,
+                 em2 = -0.0001536,
+                 em3 = 1.0 / 24490000.0,
+                 em4 = 0.0;
+   double em, dem;
+
+/* Moon's mean anomaly */
+   static double emp0 = 134.9633964,
+                 emp1 = 477198.8675055,
+                 emp2 = 0.0087414,
+                 emp3 = 1.0 / 69699.0,
+                 emp4 = -1.0 / 14712000.0;
+   double emp, demp;
+
+/* Mean distance of the Moon from its ascending node */
+   static double f0 = 93.2720950,
+                 f1 = 483202.0175233,
+                 f2 = -0.0036539,
+                 f3 = 1.0 / 3526000.0,
+                 f4 = 1.0 / 863310000.0;
+   double f, df;
+
+/*
+** Other arguments
+*/
+
+/* Meeus A_1, due to Venus (deg) */
+   static double a10 = 119.75,
+                 a11 = 131.849;
+   double a1, da1;
+
+/* Meeus A_2, due to Jupiter (deg) */
+   static double a20 = 53.09,
+                 a21 = 479264.290;
+   double a2, da2;
+
+/* Meeus A_3, due to sidereal motion of the Moon in longitude (deg) */
+   static double a30 = 313.45,
+                 a31 = 481266.484;
+   double a3, da3;
+
+/* Coefficients for Meeus "additive terms" (deg) */
+   static double al1 =  0.003958,
+                 al2 =  0.001962,
+                 al3 =  0.000318;
+   static double ab1 = -0.002235,
+                 ab2 =  0.000382,
+                 ab3 =  0.000175,
+                 ab4 =  0.000175,
+                 ab5 =  0.000127,
+                 ab6 = -0.000115;
+
+/* Fixed term in distance (m) */
+   static double r0 = 385000560.0;
+
+/* Coefficients for (dimensionless) E factor */
+   static double e1 = -0.002516,
+                 e2 = -0.0000074;
+   double e, de, esq, desq;
+
+/*
+** Coefficients for Moon longitude and distance series
+*/
+   struct termlr {
+      int nd;           /* multiple of D  in argument           */
+      int nem;          /*     "    "  M   "    "               */
+      int nemp;         /*     "    "  M'  "    "               */
+      int nf;           /*     "    "  F   "    "               */
+      double coefl;     /* coefficient of L sine argument (deg) */
+      double coefr;     /* coefficient of R cosine argument (m) */
+   };
+
+static struct termlr tlr[] = {{0,  0,  1,  0,  6.288774, -20905355.0},
+                              {2,  0, -1,  0,  1.274027,  -3699111.0},
+                              {2,  0,  0,  0,  0.658314,  -2955968.0},
+                              {0,  0,  2,  0,  0.213618,   -569925.0},
+                              {0,  1,  0,  0, -0.185116,     48888.0},
+                              {0,  0,  0,  2, -0.114332,     -3149.0},
+                              {2,  0, -2,  0,  0.058793,    246158.0},
+                              {2, -1, -1,  0,  0.057066,   -152138.0},
+                              {2,  0,  1,  0,  0.053322,   -170733.0},
+                              {2, -1,  0,  0,  0.045758,   -204586.0},
+                              {0,  1, -1,  0, -0.040923,   -129620.0},
+                              {1,  0,  0,  0, -0.034720,    108743.0},
+                              {0,  1,  1,  0, -0.030383,    104755.0},
+                              {2,  0,  0, -2,  0.015327,     10321.0},
+                              {0,  0,  1,  2, -0.012528,         0.0},
+                              {0,  0,  1, -2,  0.010980,     79661.0},
+                              {4,  0, -1,  0,  0.010675,    -34782.0},
+                              {0,  0,  3,  0,  0.010034,    -23210.0},
+                              {4,  0, -2,  0,  0.008548,    -21636.0},
+                              {2,  1, -1,  0, -0.007888,     24208.0},
+                              {2,  1,  0,  0, -0.006766,     30824.0},
+                              {1,  0, -1,  0, -0.005163,     -8379.0},
+                              {1,  1,  0,  0,  0.004987,    -16675.0},
+                              {2, -1,  1,  0,  0.004036,    -12831.0},
+                              {2,  0,  2,  0,  0.003994,    -10445.0},
+                              {4,  0,  0,  0,  0.003861,    -11650.0},
+                              {2,  0, -3,  0,  0.003665,     14403.0},
+                              {0,  1, -2,  0, -0.002689,     -7003.0},
+                              {2,  0, -1,  2, -0.002602,         0.0},
+                              {2, -1, -2,  0,  0.002390,     10056.0},
+                              {1,  0,  1,  0, -0.002348,      6322.0},
+                              {2, -2,  0,  0,  0.002236,     -9884.0},
+                              {0,  1,  2,  0, -0.002120,      5751.0},
+                              {0,  2,  0,  0, -0.002069,         0.0},
+                              {2, -2, -1,  0,  0.002048,     -4950.0},
+                              {2,  0,  1, -2, -0.001773,      4130.0},
+                              {2,  0,  0,  2, -0.001595,         0.0},
+                              {4, -1, -1,  0,  0.001215,     -3958.0},
+                              {0,  0,  2,  2, -0.001110,         0.0},
+                              {3,  0, -1,  0, -0.000892,      3258.0},
+                              {2,  1,  1,  0, -0.000810,      2616.0},
+                              {4, -1, -2,  0,  0.000759,     -1897.0},
+                              {0,  2, -1,  0, -0.000713,     -2117.0},
+                              {2,  2, -1,  0, -0.000700,      2354.0},
+                              {2,  1, -2,  0,  0.000691,         0.0},
+                              {2, -1,  0, -2,  0.000596,         0.0},
+                              {4,  0,  1,  0,  0.000549,     -1423.0},
+                              {0,  0,  4,  0,  0.000537,     -1117.0},
+                              {4, -1,  0,  0,  0.000520,     -1571.0},
+                              {1,  0, -2,  0, -0.000487,     -1739.0},
+                              {2,  1,  0, -2, -0.000399,         0.0},
+                              {0,  0,  2, -2, -0.000381,     -4421.0},
+                              {1,  1,  1,  0,  0.000351,         0.0},
+                              {3,  0, -2,  0, -0.000340,         0.0},
+                              {4,  0, -3,  0,  0.000330,         0.0},
+                              {2, -1,  2,  0,  0.000327,         0.0},
+                              {0,  2,  1,  0, -0.000323,      1165.0},
+                              {1,  1, -1,  0,  0.000299,         0.0},
+                              {2,  0,  3,  0,  0.000294,         0.0},
+                              {2,  0, -1, -2,  0.000000,      8752.0}};
+
+   static int NLR = ( sizeof tlr / sizeof ( struct termlr ) );
+
+/*
+** Coefficients for Moon latitude series
+*/
+   struct termb {
+      int nd;           /* multiple of D  in argument           */
+      int nem;          /*     "    "  M   "    "               */
+      int nemp;         /*     "    "  M'  "    "               */
+      int nf;           /*     "    "  F   "    "               */
+      double coefb;     /* coefficient of B sine argument (deg) */
+   };
+
+static struct termb tb[] = {{0,  0,  0,  1,  5.128122},
+                            {0,  0,  1,  1,  0.280602},
+                            {0,  0,  1, -1,  0.277693},
+                            {2,  0,  0, -1,  0.173237},
+                            {2,  0, -1,  1,  0.055413},
+                            {2,  0, -1, -1,  0.046271},
+                            {2,  0,  0,  1,  0.032573},
+                            {0,  0,  2,  1,  0.017198},
+                            {2,  0,  1, -1,  0.009266},
+                            {0,  0,  2, -1,  0.008822},
+                            {2, -1,  0, -1,  0.008216},
+                            {2,  0, -2, -1,  0.004324},
+                            {2,  0,  1,  1,  0.004200},
+                            {2,  1,  0, -1, -0.003359},
+                            {2, -1, -1,  1,  0.002463},
+                            {2, -1,  0,  1,  0.002211},
+                            {2, -1, -1, -1,  0.002065},
+                            {0,  1, -1, -1, -0.001870},
+                            {4,  0, -1, -1,  0.001828},
+                            {0,  1,  0,  1, -0.001794},
+                            {0,  0,  0,  3, -0.001749},
+                            {0,  1, -1,  1, -0.001565},
+                            {1,  0,  0,  1, -0.001491},
+                            {0,  1,  1,  1, -0.001475},
+                            {0,  1,  1, -1, -0.001410},
+                            {0,  1,  0, -1, -0.001344},
+                            {1,  0,  0, -1, -0.001335},
+                            {0,  0,  3,  1,  0.001107},
+                            {4,  0,  0, -1,  0.001021},
+                            {4,  0, -1,  1,  0.000833},
+                            {0,  0,  1, -3,  0.000777},
+                            {4,  0, -2,  1,  0.000671},
+                            {2,  0,  0, -3,  0.000607},
+                            {2,  0,  2, -1,  0.000596},
+                            {2, -1,  1, -1,  0.000491},
+                            {2,  0, -2,  1, -0.000451},
+                            {0,  0,  3, -1,  0.000439},
+                            {2,  0,  2,  1,  0.000422},
+                            {2,  0, -3, -1,  0.000421},
+                            {2,  1, -1,  1, -0.000366},
+                            {2,  1,  0,  1, -0.000351},
+                            {4,  0,  0,  1,  0.000331},
+                            {2, -1,  1,  1,  0.000315},
+                            {2, -2,  0, -1,  0.000302},
+                            {0,  0,  1,  3, -0.000283},
+                            {2,  1,  1, -1, -0.000229},
+                            {1,  1,  0, -1,  0.000223},
+                            {1,  1,  0,  1,  0.000223},
+                            {0,  1, -2, -1, -0.000220},
+                            {2,  1, -1, -1, -0.000220},
+                            {1,  0,  1,  1, -0.000185},
+                            {2, -1, -2, -1,  0.000181},
+                            {0,  1,  2,  1, -0.000177},
+                            {4,  0, -2, -1,  0.000176},
+                            {4, -1, -1, -1,  0.000166},
+                            {1,  0,  1, -1, -0.000164},
+                            {4,  0,  1, -1,  0.000132},
+                            {1,  0, -1, -1, -0.000119},
+                            {4, -1,  0, -1,  0.000115},
+                            {2, -2,  0,  1,  0.000107}};
+
+   static int NB = ( sizeof tb / sizeof ( struct termb ) );
+
+/* Miscellaneous */
+   int n, i;
+   double t, elpmf, delpmf, vel, vdel, vr, vdr, a1mf, da1mf, a1pf,
+          da1pf, dlpmp, slpmp, vb, vdb, v, dv, emn, empn, dn, fn, en,
+          den, arg, darg, farg, coeff, el, del, r, dr, b, db, gamb,
+          phib, psib, epsa, rm[3][3];
+
+/* ------------------------------------------------------------------ */
+
+/* Centuries since J2000.0 */
+   t = ((date1 - ERFA_DJ00) + date2) / ERFA_DJC;
+
+/* --------------------- */
+/* Fundamental arguments */
+/* --------------------- */
+
+/* Arguments (radians) and derivatives (radians per Julian century)
+   for the current date. */
+
+/* Moon's mean longitude. */
+   elp = ERFA_DD2R * fmod ( elp0
+                   + ( elp1
+                   + ( elp2
+                   + ( elp3
+                   +   elp4 * t ) * t ) * t ) * t, 360.0 );
+   delp = ERFA_DD2R * (     elp1
+                   + ( elp2 * 2.0
+                   + ( elp3 * 3.0
+                   +   elp4 * 4.0 * t ) * t ) * t );
+
+/* Moon's mean elongation. */
+   d = ERFA_DD2R * fmod ( d0
+                 + ( d1
+                 + ( d2
+                 + ( d3
+                 +   d4 * t ) * t ) * t ) * t, 360.0 );
+   dd = ERFA_DD2R * (     d1
+                 + ( d2 * 2.0
+                 + ( d3 * 3.0
+                 +   d4 * 4.0 * t ) * t ) * t );
+
+/* Sun's mean anomaly. */
+   em = ERFA_DD2R * fmod ( em0
+                  + ( em1
+                  + ( em2
+                  + ( em3
+                  +   em4 * t ) * t ) * t ) * t, 360.0 );
+   dem = ERFA_DD2R * (     em1
+                  + ( em2 * 2.0
+                  + ( em3 * 3.0
+                  +   em4 * 4.0 * t ) * t ) * t );
+
+/* Moon's mean anomaly. */
+   emp = ERFA_DD2R * fmod ( emp0
+                   + ( emp1
+                   + ( emp2
+                   + ( emp3
+                   +   emp4 * t ) * t ) * t ) * t, 360.0 );
+   demp = ERFA_DD2R * (     emp1
+                   + ( emp2 * 2.0
+                   + ( emp3 * 3.0
+                   +   emp4 * 4.0 * t ) * t ) * t );
+
+/* Mean distance of the Moon from its ascending node. */
+   f = ERFA_DD2R * fmod ( f0
+                 + ( f1
+                 + ( f2
+                 + ( f3
+                 +   f4 * t ) * t ) * t ) * t, 360.0 );
+   df = ERFA_DD2R * (     f1
+                 + ( f2 * 2.0
+                 + ( f3 * 3.0
+                 +   f4 * 4.0 * t ) * t ) * t );
+
+/* Meeus further arguments. */
+   a1 = ERFA_DD2R * ( a10 + a11*t );
+   da1 = ERFA_DD2R * al1;
+   a2 = ERFA_DD2R * ( a20 + a21*t );
+   da2 = ERFA_DD2R * a21;
+   a3 = ERFA_DD2R * ( a30 + a31*t );
+   da3 = ERFA_DD2R * a31;
+
+/* E-factor, and square. */
+   e = 1.0 + ( e1 + e2*t ) * t;
+   de = e1 + 2.0*e2*t;
+   esq = e*e;
+   desq = 2.0*e*de;
+
+/* Use the Meeus additive terms (deg) to start off the summations. */
+   elpmf = elp - f;
+   delpmf = delp - df;
+   vel = al1 * sin(a1)
+       + al2 * sin(elpmf)
+       + al3 * sin(a2);
+   vdel = al1 * cos(a1) * da1
+        + al2 * cos(elpmf) * delpmf
+        + al3 * cos(a2) * da2;
+
+   vr = 0.0;
+   vdr = 0.0;
+
+   a1mf = a1 - f;
+   da1mf = da1 - df;
+   a1pf = a1 + f;
+   da1pf = da1 + df;
+   dlpmp = elp - emp;
+   slpmp = elp + emp;
+   vb = ab1 * sin(elp)
+      + ab2 * sin(a3)
+      + ab3 * sin(a1mf)
+      + ab4 * sin(a1pf)
+      + ab5 * sin(dlpmp)
+      + ab6 * sin(slpmp);
+   vdb = ab1 * cos(elp) * delp
+       + ab2 * cos(a3) * da3
+       + ab3 * cos(a1mf) * da1mf
+       + ab4 * cos(a1pf) * da1pf
+       + ab5 * cos(dlpmp) * (delp-demp)
+       + ab6 * cos(slpmp) * (delp+demp);
+
+/* ----------------- */
+/* Series expansions */
+/* ----------------- */
+
+/* Longitude and distance plus derivatives. */
+   for ( n = NLR-1; n >= 0; n-- ) {
+      dn = (double) tlr[n].nd;
+      emn = (double) ( i = tlr[n].nem );
+      empn = (double) tlr[n].nemp;
+      fn = (double) tlr[n].nf;
+      switch ( abs(i) ) {
+      case 1:
+         en = e;
+         den = de;
+         break;
+      case 2:
+         en = esq;
+         den = desq;
+         break;
+      default:
+         en = 1.0;
+         den = 0.0;
+      }
+      arg = dn*d + emn*em + empn*emp + fn*f;
+      darg = dn*dd + emn*dem + empn*demp + fn*df;
+      farg = sin(arg);
+      v = farg * en;
+      dv = cos(arg)*darg*en + farg*den;
+      coeff = tlr[n].coefl;
+      vel += coeff * v;
+      vdel += coeff * dv;
+      farg = cos(arg);
+      v = farg * en;
+      dv = -sin(arg)*darg*en + farg*den;
+      coeff = tlr[n].coefr;
+      vr += coeff * v;
+      vdr += coeff * dv;
+   }
+   el = elp + ERFA_DD2R*vel;
+   del = ( delp + ERFA_DD2R*vdel ) / ERFA_DJC;
+   r = ( vr + r0 ) / ERFA_DAU;
+   dr = vdr / ERFA_DAU / ERFA_DJC;
+
+/* Latitude plus derivative. */
+   for ( n = NB-1; n >= 0; n-- ) {
+      dn = (double) tb[n].nd;
+      emn = (double) ( i = tb[n].nem );
+      empn = (double) tb[n].nemp;
+      fn = (double) tb[n].nf;
+      switch ( abs(i) ) {
+      case 1:
+         en = e;
+         den = de;
+         break;
+      case 2:
+         en = esq;
+         den = desq;
+         break;
+      default:
+         en = 1.0;
+         den = 0.0;
+      }
+      arg = dn*d + emn*em + empn*emp + fn*f;
+      darg = dn*dd + emn*dem + empn*demp + fn*df;
+      farg = sin(arg);
+      v = farg * en;
+      dv = cos(arg)*darg*en + farg*den;
+      coeff = tb[n].coefb;
+      vb += coeff * v;
+      vdb += coeff * dv;
+   }
+   b = vb * ERFA_DD2R;
+   db = vdb * ERFA_DD2R / ERFA_DJC;
+
+/* ------------------------------ */
+/* Transformation into final form */
+/* ------------------------------ */
+
+/* Longitude, latitude to x, y, z (AU). */
+   eraS2pv ( el, b, r, del, db, dr, pv );
+
+/* IAU 2006 Fukushima-Williams bias+precession angles. */
+   eraPfw06 ( date1, date2, &gamb, &phib, &psib, &epsa );
+
+/* Mean ecliptic coordinates to GCRS rotation matrix. */
+   eraIr ( rm );
+   eraRz ( psib, rm );
+   eraRx ( -phib, rm );
+   eraRz ( -gamb, rm );
+
+/* Rotate the Moon position and velocity into GCRS (Note 6). */
+   eraRxpv ( rm, pv, pv );
+
+/* Finished. */
+
+}
+/*----------------------------------------------------------------------
+**  
+**  
+**  Copyright (C) 2013-2021, NumFOCUS Foundation.
+**  All rights reserved.
+**  
+**  This library is derived, with permission, from the International
+**  Astronomical Union's "Standards of Fundamental Astronomy" library,
+**  available from http://www.iausofa.org.
+**  
+**  The ERFA version is intended to retain identical functionality to
+**  the SOFA library, but made distinct through different function and
+**  file names, as set out in the SOFA license conditions.  The SOFA
+**  original has a role as a reference standard for the IAU and IERS,
+**  and consequently redistribution is permitted only in its unaltered
+**  state.  The ERFA version is not subject to this restriction and
+**  therefore can be included in distributions which do not support the
+**  concept of "read only" software.
+**  
+**  Although the intent is to replicate the SOFA API (other than
+**  replacement of prefix names) and results (with the exception of
+**  bugs;  any that are discovered will be fixed), SOFA is not
+**  responsible for any errors found in this version of the library.
+**  
+**  If you wish to acknowledge the SOFA heritage, please acknowledge
+**  that you are using a library derived from SOFA, rather than SOFA
+**  itself.
+**  
+**  
+**  TERMS AND CONDITIONS
+**  
+**  Redistribution and use in source and binary forms, with or without
+**  modification, are permitted provided that the following conditions
+**  are met:
+**  
+**  1 Redistributions of source code must retain the above copyright
+**    notice, this list of conditions and the following disclaimer.
+**  
+**  2 Redistributions in binary form must reproduce the above copyright
+**    notice, this list of conditions and the following disclaimer in
+**    the documentation and/or other materials provided with the
+**    distribution.
+**  
+**  3 Neither the name of the Standards Of Fundamental Astronomy Board,
+**    the International Astronomical Union nor the names of its
+**    contributors may be used to endorse or promote products derived
+**    from this software without specific prior written permission.
+**  
+**  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+**  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+**  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+**  FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+**  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+**  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+**  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+**  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+**  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+**  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+**  POSSIBILITY OF SUCH DAMAGE.
+**  
+*/

--- a/src/num00a.c
+++ b/src/num00a.c
@@ -52,7 +52,7 @@ void eraNum00a(double date1, double date2, double rmatn[3][3])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.222-3 (p114).
 **
-**  This revision:  2020 November 27
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -65,7 +65,7 @@ void eraNum00a(double date1, double date2, double rmatn[3][3])
    eraPn00a(date1, date2,
             &dpsi, &deps, &epsa, rb, rp, rbp, rmatn, rbpn);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/num00b.c
+++ b/src/num00b.c
@@ -52,7 +52,7 @@ void eraNum00b(double date1, double date2, double rmatn[3][3])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.222-3 (p114).
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -65,7 +65,7 @@ void eraNum00b(double date1, double date2, double rmatn[3][3])
    eraPn00b(date1, date2,
             &dpsi, &deps, &epsa, rb, rp, rbp, rmatn, rbpn);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/num06a.c
+++ b/src/num06a.c
@@ -51,7 +51,7 @@ void eraNum06a(double date1, double date2, double rmatn[3][3])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.222-3 (p114).
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -69,7 +69,7 @@ void eraNum06a(double date1, double date2, double rmatn[3][3])
 /* Nutation matrix. */
    eraNumat(eps, dp, de, rmatn);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/numat.c
+++ b/src/numat.c
@@ -41,7 +41,7 @@ void eraNumat(double epsa, double dpsi, double deps, double rmatn[3][3])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.222-3 (p114).
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -53,7 +53,7 @@ void eraNumat(double epsa, double dpsi, double deps, double rmatn[3][3])
    eraRz(-dpsi, rmatn);
    eraRx(-(epsa + deps), rmatn);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/nut00a.c
+++ b/src/nut00a.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraNut00a(double date1, double date2, double *dpsi, double *deps)
 /*
@@ -148,7 +149,7 @@ void eraNut00a(double date1, double date2, double *dpsi, double *deps)
 **     Wallace, P.T., "Software for Implementing the IAU 2000
 **     Resolutions", in IERS Workshop 5.1 (2002)
 **
-**  This revision:  2019 June 23
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -1991,7 +1992,7 @@ void eraNut00a(double date1, double date2, double *dpsi, double *deps)
    *dpsi = dpsils + dpsipl;
    *deps = depsls + depspl;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/nut00b.c
+++ b/src/nut00b.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraNut00b(double date1, double date2, double *dpsi, double *deps)
 /*
@@ -116,7 +117,7 @@ void eraNut00b(double date1, double date2, double *dpsi, double *deps)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J., Astron.Astrophys. 282, 663-683 (1994)
 **
-**  This revision:  2019 June 23
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -316,7 +317,7 @@ void eraNut00b(double date1, double date2, double *dpsi, double *deps)
    *dpsi = dpsils + dpsipl;
    *deps = depsls + depspl;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/nut06a.c
+++ b/src/nut06a.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraNut06a(double date1, double date2, double *dpsi, double *deps)
 /*
@@ -75,7 +76,7 @@ void eraNut06a(double date1, double date2, double *dpsi, double *deps)
 **     Wallace, P.T., "Software for Implementing the IAU 2000
 **     Resolutions", in IERS Workshop 5.1 (2002)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -97,7 +98,7 @@ void eraNut06a(double date1, double date2, double *dpsi, double *deps)
    *dpsi = dp + dp * (0.4697e-6 + fj2);
    *deps = de + de * fj2;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/nut80.c
+++ b/src/nut80.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraNut80(double date1, double date2, double *dpsi, double *deps)
 /*
@@ -48,7 +49,7 @@ void eraNut80(double date1, double date2, double *dpsi, double *deps)
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.222 (p111).
 **
-**  This revision:  2019 June 23
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -269,7 +270,7 @@ void eraNut80(double date1, double date2, double *dpsi, double *deps)
    *dpsi = dp * U2R;
    *deps = de * U2R;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/nutm80.c
+++ b/src/nutm80.c
@@ -45,7 +45,7 @@ void eraNutm80(double date1, double date2, double rmatn[3][3])
 **     eraObl80     mean obliquity, IAU 1980
 **     eraNumat     form nutation matrix
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -61,7 +61,7 @@ void eraNutm80(double date1, double date2, double rmatn[3][3])
 /* Build the rotation matrix. */
    eraNumat(epsa, dpsi, deps, rmatn);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/obl06.c
+++ b/src/obl06.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraObl06(double date1, double date2)
 /*
@@ -42,7 +43,7 @@ double eraObl06(double date1, double date2)
 **
 **     Hilton, J. et al., 2006, Celest.Mech.Dyn.Astron. 94, 351
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -63,6 +64,8 @@ double eraObl06(double date1, double date2)
           ( -0.0000000434) * t) * t) * t) * t) * t) * ERFA_DAS2R;
 
    return eps0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/obl80.c
+++ b/src/obl80.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraObl80(double date1, double date2)
 /*
@@ -44,7 +45,7 @@ double eraObl80(double date1, double date2)
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Expression 3.222-1 (p114).
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -63,6 +64,8 @@ double eraObl80(double date1, double date2)
                   ( 0.001813) * t) * t) * t);
 
    return eps0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/p06e.c
+++ b/src/p06e.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraP06e(double date1, double date2,
              double *eps0, double *psia, double *oma, double *bpa,
@@ -127,7 +128,7 @@ void eraP06e(double date1, double date2,
 **  Called:
 **     eraObl06     mean obliquity, IAU 2006
 **
-**  This revision:  2020 June 2
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -272,7 +273,7 @@ void eraP06e(double date1, double date2,
           (   -0.0000000148 )
           * t) * t) * t) * t) * t * ERFA_DAS2R;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/p2pv.c
+++ b/src/p2pv.c
@@ -18,7 +18,7 @@ void eraP2pv(double p[3], double pv[2][3])
 **     eraCp        copy p-vector
 **     eraZp        zero p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -27,7 +27,7 @@ void eraP2pv(double p[3], double pv[2][3])
    eraCp(p, pv[0]);
    eraZp(pv[1]);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/p2s.c
+++ b/src/p2s.c
@@ -26,7 +26,7 @@ void eraP2s(double p[3], double *theta, double *phi, double *r)
 **     eraC2s       p-vector to spherical
 **     eraPm        modulus of p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -35,7 +35,7 @@ void eraP2s(double p[3], double *theta, double *phi, double *r)
    eraC2s(p, theta, phi);
    *r = eraPm(p);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pap.c
+++ b/src/pap.c
@@ -37,7 +37,7 @@ double eraPap(double a[3], double b[3])
 **     eraPmp       p-vector minus p-vector
 **     eraPdp       scalar product of two p-vectors
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -84,6 +84,8 @@ double eraPap(double a[3], double b[3])
    pa = atan2(st, ct);
 
    return pa;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pas.c
+++ b/src/pas.c
@@ -26,7 +26,7 @@ double eraPas(double al, double ap, double bl, double bp)
 **
 **  2) Zero is returned if the two points are coincident.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -41,6 +41,8 @@ double eraPas(double al, double ap, double bl, double bp)
    pa = ((x != 0.0) || (y != 0.0)) ? atan2(y, x) : 0.0;
 
    return pa;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pb06.c
+++ b/src/pb06.c
@@ -63,7 +63,7 @@ void eraPb06(double date1, double date2,
 **     eraPmat06    PB matrix, IAU 2006
 **     eraRz        rotate around Z-axis
 **
-**  This revision:  2020 May 27
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -95,6 +95,8 @@ void eraPb06(double date1, double date2,
    y = -r[1][0];
    x = r[1][1];
    *bzeta = ( x != 0.0 || y != 0.0 ) ? - atan2(y,x) : 0.0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pdp.c
+++ b/src/pdp.c
@@ -15,7 +15,7 @@ double eraPdp(double a[3], double b[3])
 **  Returned (function value):
 **            double        a . b
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -29,6 +29,8 @@ double eraPdp(double a[3], double b[3])
       + a[2] * b[2];
 
    return w;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pfw06.c
+++ b/src/pfw06.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraPfw06(double date1, double date2,
               double *gamb, double *phib, double *psib, double *epsa)
@@ -73,7 +74,7 @@ void eraPfw06(double date1, double date2,
 **  Called:
 **     eraObl06     mean obliquity, IAU 2006
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -109,7 +110,7 @@ void eraPfw06(double date1, double date2,
            * t) * t) * t) * t) * t) * ERFA_DAS2R;
    *epsa =  eraObl06(date1, date2);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/plan94.c
+++ b/src/plan94.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraPlan94(double date1, double date2, int np, double pv[2][3])
 /*
@@ -9,6 +10,8 @@ int eraPlan94(double date1, double date2, int np, double pv[2][3])
 **  Approximate heliocentric position and velocity of a nominated major
 **  planet:  Mercury, Venus, EMB, Mars, Jupiter, Saturn, Uranus or
 **  Neptune (but not the Earth itself).
+**
+**  n.b. Not IAU-endorsed and without canonical status.
 **
 **  Given:
 **     date1  double       TDB date part A (Note 1)
@@ -151,13 +154,13 @@ int eraPlan94(double date1, double date2, int np, double pv[2][3])
 **     which in turn takes precedence over the remote date warning.
 **
 **  Called:
-**     eraAnp       normalize angle into range 0 to 2pi
+**     eraAnpm      normalize angle into range +/- pi
 **
 **  Reference:  Simon, J.L, Bretagnon, P., Chapront, J.,
 **              Chapront-Touze, M., Francou, G., and Laskar, J.,
 **              Astron.Astrophys., 282, 663 (1994).
 **
-**  This revision:  2019 June 23
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -459,6 +462,8 @@ int eraPlan94(double date1, double date2, int np, double pv[2][3])
 
 /* Return the status. */
    return jstat;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pm.c
+++ b/src/pm.c
@@ -14,13 +14,15 @@ double eraPm(double p[3])
 **  Returned (function value):
 **            double        modulus
 **
-**  This revision:  2013 August 7
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 {
    return sqrt( p[0]*p[0] + p[1]*p[1] + p[2]*p[2] );
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pmat00.c
+++ b/src/pmat00.c
@@ -50,7 +50,7 @@ void eraPmat00(double date1, double date2, double rbp[3][3])
 **     24th General Assembly, Manchester, UK.  Resolutions B1.3, B1.6.
 **     (2000)
 **
-**  This revision:  2020 November 24
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -62,7 +62,7 @@ void eraPmat00(double date1, double date2, double rbp[3][3])
 /* Obtain the required matrix (discarding others). */
    eraBp00(date1, date2, rb, rp, rbp);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pmat06.c
+++ b/src/pmat06.c
@@ -55,7 +55,7 @@ void eraPmat06(double date1, double date2, double rbp[3][3])
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2020 November 24
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -70,7 +70,7 @@ void eraPmat06(double date1, double date2, double rbp[3][3])
 /* Form the matrix. */
    eraFw2m(gamb, phib, psib, epsa, rbp);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pmat76.c
+++ b/src/pmat76.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraPmat76(double date1, double date2, double rmatp[3][3])
 /*
@@ -66,7 +67,7 @@ void eraPmat76(double date1, double date2, double rmatp[3][3])
 **
 **     Kaplan,G.H., 1981. USNO circular no. 163, pA2.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -85,7 +86,7 @@ void eraPmat76(double date1, double date2, double rmatp[3][3])
    eraRz( -z, wmat);
    eraCr( wmat, rmatp);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pmp.c
+++ b/src/pmp.c
@@ -19,7 +19,7 @@ void eraPmp(double a[3], double b[3], double amb[3])
 **     It is permissible to re-use the same array for any of the
 **     arguments.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -29,7 +29,7 @@ void eraPmp(double a[3], double b[3], double amb[3])
    amb[1] = a[1] - b[1];
    amb[2] = a[2] - b[2];
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pmpx.c
+++ b/src/pmpx.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraPmpx(double rc, double dc, double pr, double pd,
              double px, double rv, double pmt, double pob[3],
@@ -12,7 +13,7 @@ void eraPmpx(double rc, double dc, double pr, double pd,
 **
 **  Given:
 **     rc,dc  double     ICRS RA,Dec at catalog epoch (radians)
-**     pr     double     RA proper motion (radians/year; Note 1)
+**     pr     double     RA proper motion (radians/year, Note 1)
 **     pd     double     Dec proper motion (radians/year)
 **     px     double     parallax (arcsec)
 **     rv     double     radial velocity (km/s, +ve if receding)
@@ -46,7 +47,7 @@ void eraPmpx(double rc, double dc, double pr, double pd,
 **     eraPdp       scalar product of two p-vectors
 **     eraPn        decompose p-vector into modulus and direction
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 April 3
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/pn.c
+++ b/src/pn.c
@@ -28,7 +28,7 @@ void eraPn(double p[3], double *r, double u[3])
 **     eraZp        zero p-vector
 **     eraSxp       multiply p-vector by scalar
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -53,7 +53,7 @@ void eraPn(double p[3], double *r, double u[3])
 /* Return the modulus. */
    *r = w;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pn00.c
+++ b/src/pn00.c
@@ -95,7 +95,7 @@ void eraPn00(double date1, double date2, double dpsi, double deps,
 **     n.b. The celestial ephemeris origin (CEO) was renamed "celestial
 **          intermediate origin" (CIO) by IAU 2006 Resolution 2.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -121,7 +121,7 @@ void eraPn00(double date1, double date2, double dpsi, double deps,
 /* Bias-precession-nutation matrix (classical). */
    eraRxr(rnw, rbpw, rbpn);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pn00a.c
+++ b/src/pn00a.c
@@ -95,7 +95,7 @@ void eraPn00a(double date1, double date2,
 **     n.b. The celestial ephemeris origin (CEO) was renamed "celestial
 **          intermediate origin" (CIO) by IAU 2006 Resolution 2.
 **
-**  This revision:  2020 November 25
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -107,7 +107,7 @@ void eraPn00a(double date1, double date2,
 /* Remaining results. */
    eraPn00(date1, date2, *dpsi, *deps, epsa, rb, rp, rbp, rn, rbpn);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pn00b.c
+++ b/src/pn00b.c
@@ -95,7 +95,7 @@ void eraPn00b(double date1, double date2,
 **     n.b. The celestial ephemeris origin (CEO) was renamed "celestial
 **          intermediate origin" (CIO) by IAU 2006 Resolution 2.
 **
-**  This revision:  2020 November 25
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -107,7 +107,7 @@ void eraPn00b(double date1, double date2,
 /* Remaining results. */
    eraPn00(date1, date2, *dpsi, *deps, epsa, rb, rp, rbp, rn, rbpn);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pn06.c
+++ b/src/pn06.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraPn06(double date1, double date2, double dpsi, double deps,
              double *epsa,
@@ -93,7 +94,7 @@ void eraPn06(double date1, double date2, double dpsi, double deps,
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2020 November 25
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -131,7 +132,7 @@ void eraPn06(double date1, double date2, double dpsi, double deps,
 /* Obliquity, mean of date. */
    *epsa = eps;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pn06a.c
+++ b/src/pn06a.c
@@ -85,7 +85,7 @@ void eraPn06a(double date1, double date2,
 **
 **     Capitaine, N. & Wallace, P.T., 2006, Astron.Astrophys. 450, 855
 **
-**  This revision:  2013 November 13
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -97,7 +97,7 @@ void eraPn06a(double date1, double date2,
 /* Remaining results. */
    eraPn06(date1, date2, *dpsi, *deps, epsa, rb, rp, rbp, rn, rbpn);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pnm00a.c
+++ b/src/pnm00a.c
@@ -53,7 +53,7 @@ void eraPnm00a(double date1, double date2, double rbpn[3][3])
 **     24th General Assembly, Manchester, UK.  Resolutions B1.3, B1.6.
 **     (2000)
 **
-**  This revision:  2020 November 27
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -65,7 +65,7 @@ void eraPnm00a(double date1, double date2, double rbpn[3][3])
 /* Obtain the required matrix (discarding other results). */
    eraPn00a(date1, date2, &dpsi, &deps, &epsa, rb, rp, rbp, rn, rbpn);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pnm00b.c
+++ b/src/pnm00b.c
@@ -53,7 +53,7 @@ void eraPnm00b(double date1, double date2, double rbpn[3][3])
 **     24th General Assembly, Manchester, UK.  Resolutions B1.3, B1.6.
 **     (2000)
 **
-**  This revision:  2020 November 27
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -65,7 +65,7 @@ void eraPnm00b(double date1, double date2, double rbpn[3][3])
 /* Obtain the required matrix (discarding other results). */
    eraPn00b(date1, date2, &dpsi, &deps, &epsa, rb, rp, rbp, rn, rbpn);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pnm06a.c
+++ b/src/pnm06a.c
@@ -51,7 +51,7 @@ void eraPnm06a(double date1, double date2, double rbpn[3][3])
 **
 **     Capitaine, N. & Wallace, P.T., 2006, Astron.Astrophys. 450, 855.
 **
-**  This revision:  2020 November 27
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -69,7 +69,7 @@ void eraPnm06a(double date1, double date2, double rbpn[3][3])
 /* Equinox based nutation x precession x bias matrix. */
    eraFw2m(gamb, phib, psib + dp, epsa + de, rbpn);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pnm80.c
+++ b/src/pnm80.c
@@ -52,7 +52,7 @@ void eraPnm80(double date1, double date2, double rmatpn[3][3])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.3 (p145).
 **
-**  This revision:  2020 November 27
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -70,7 +70,7 @@ void eraPnm80(double date1, double date2, double rmatpn[3][3])
 /* Combine the matrices:  PN = N x P. */
    eraRxr(rmatn, rmatp, rmatpn);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pom00.c
+++ b/src/pom00.c
@@ -46,7 +46,7 @@ void eraPom00(double xp, double yp, double sp, double rpom[3][3])
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2020 October 31
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -59,7 +59,7 @@ void eraPom00(double xp, double yp, double sp, double rpom[3][3])
    eraRy(-xp, rpom);
    eraRx(-yp, rpom);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ppp.c
+++ b/src/ppp.c
@@ -19,7 +19,7 @@ void eraPpp(double a[3], double b[3], double apb[3])
 **     It is permissible to re-use the same array for any of the
 **     arguments.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -29,7 +29,7 @@ void eraPpp(double a[3], double b[3], double apb[3])
    apb[1] = a[1] + b[1];
    apb[2] = a[2] + b[2];
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ppsp.c
+++ b/src/ppsp.c
@@ -23,7 +23,7 @@ void eraPpsp(double a[3], double s, double b[3], double apsb[3])
 **     eraSxp       multiply p-vector by scalar
 **     eraPpp       p-vector plus p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -38,7 +38,7 @@ void eraPpsp(double a[3], double s, double b[3], double apsb[3])
 /* a + s*b. */
    eraPpp(a, sb, apsb);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pr00.c
+++ b/src/pr00.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraPr00(double date1, double date2, double *dpsipr, double *depspr)
 /*
@@ -66,7 +67,7 @@ void eraPr00(double date1, double date2, double *dpsipr, double *depspr)
 **     Wallace, P.T., "Software for Implementing the IAU 2000
 **     Resolutions", in IERS Workshop 5.1 (2002).
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -86,7 +87,7 @@ void eraPr00(double date1, double date2, double *dpsipr, double *depspr)
    *dpsipr = PRECOR * t;
    *depspr = OBLCOR * t;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/prec76.c
+++ b/src/prec76.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraPrec76(double date01, double date02, double date11, double date12,
                double *zeta, double *z, double *theta)
@@ -66,7 +67,7 @@ void eraPrec76(double date01, double date02, double date11, double date12,
 **     Lieske, J.H., 1979, Astron.Astrophys. 73, 282, equations
 **     (6) & (7), p283.
 **
-**  This revision:  2013 November 19
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -92,7 +93,7 @@ void eraPrec76(double date01, double date02, double date11, double date12,
    *theta = ((2004.3109 + (-0.85330 - 0.000217 * t0) * t0)
           + ((-0.42665 - 0.000217 * t0) - 0.041833 * t) * t) * tas2r;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pv2p.c
+++ b/src/pv2p.c
@@ -17,7 +17,7 @@ void eraPv2p(double pv[2][3], double p[3])
 **  Called:
 **     eraCp        copy p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -25,7 +25,7 @@ void eraPv2p(double pv[2][3], double p[3])
 {
    eraCp(pv[0], p);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pv2s.c
+++ b/src/pv2s.c
@@ -34,7 +34,7 @@ void eraPv2s(double pv[2][3],
 **  2) If the position is a pole, theta, td and pd are indeterminate.
 **     In such cases zeroes are returned for all three.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -88,7 +88,7 @@ void eraPv2s(double pv[2][3],
    *r = rtrue;
    *rd = (rw != 0.0) ? (xyp + z*zd) / rw : 0.0;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pvdpv.c
+++ b/src/pvdpv.c
@@ -25,7 +25,7 @@ void eraPvdpv(double a[2][3], double b[2][3], double adb[2])
 **  Called:
 **     eraPdp       scalar product of two p-vectors
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -46,7 +46,7 @@ void eraPvdpv(double a[2][3], double b[2][3], double adb[2])
 /* Velocity part of result. */
    adb[1] = adbd + addb;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pvm.c
+++ b/src/pvm.c
@@ -18,7 +18,7 @@ void eraPvm(double pv[2][3], double *r, double *s)
 **  Called:
 **     eraPm        modulus of p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -30,7 +30,7 @@ void eraPvm(double pv[2][3], double *r, double *s)
 /* Speed. */
    *s = eraPm(pv[1]);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pvmpv.c
+++ b/src/pvmpv.c
@@ -22,7 +22,7 @@ void eraPvmpv(double a[2][3], double b[2][3], double amb[2][3])
 **  Called:
 **     eraPmp       p-vector minus p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -31,7 +31,7 @@ void eraPvmpv(double a[2][3], double b[2][3], double amb[2][3])
    eraPmp(a[0], b[0], amb[0]);
    eraPmp(a[1], b[1], amb[1]);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pvppv.c
+++ b/src/pvppv.c
@@ -22,7 +22,7 @@ void eraPvppv(double a[2][3], double b[2][3], double apb[2][3])
 **  Called:
 **     eraPpp       p-vector plus p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -31,7 +31,7 @@ void eraPvppv(double a[2][3], double b[2][3], double apb[2][3])
    eraPpp(a[0], b[0], apb[0]);
    eraPpp(a[1], b[1], apb[1]);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pvstar.c
+++ b/src/pvstar.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraPvstar(double pv[2][3], double *ra, double *dec,
               double *pmr, double *pmd, double *px, double *rv)
@@ -93,7 +94,7 @@ int eraPvstar(double pv[2][3], double *ra, double *dec,
 **
 **     Stumpff, P., 1985, Astron.Astrophys. 144, 232-240.
 **
-**  This revision:  2017 March 16
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -150,8 +151,10 @@ int eraPvstar(double pv[2][3], double *ra, double *dec,
 /* Return radial velocity in km/s. */
    *rv = 1e-3 * rd * ERFA_DAU / ERFA_DAYSEC;
 
-/* OK status. */
+/* Success. */
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pvtob.c
+++ b/src/pvtob.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraPvtob(double elong, double phi, double hm,
               double xp, double yp, double sp, double theta,
@@ -61,7 +62,7 @@ void eraPvtob(double elong, double phi, double hm,
 **     eraPom00     polar motion matrix
 **     eraTrxp      product of transpose of r-matrix and p-vector
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 February 24
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/pvu.c
+++ b/src/pvu.c
@@ -28,7 +28,7 @@ void eraPvu(double dt, double pv[2][3], double upv[2][3])
 **     eraPpsp      p-vector plus scaled p-vector
 **     eraCp        copy p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -37,7 +37,7 @@ void eraPvu(double dt, double pv[2][3], double upv[2][3])
    eraPpsp(pv[0], dt, pv[1], upv[0]);
    eraCp(pv[1], upv[1]);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pvup.c
+++ b/src/pvup.c
@@ -22,7 +22,7 @@ void eraPvup(double dt, double pv[2][3], double p[3])
 **
 **  2) The time units of dt must match those of the velocity.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -32,7 +32,7 @@ void eraPvup(double dt, double pv[2][3], double p[3])
    p[1] = pv[0][1] + dt * pv[1][1];
    p[2] = pv[0][2] + dt * pv[1][2];
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pvxpv.c
+++ b/src/pvxpv.c
@@ -30,7 +30,7 @@ void eraPvxpv(double a[2][3], double b[2][3], double axb[2][3])
 **     eraPxp       vector product of two p-vectors
 **     eraPpp       p-vector plus p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -51,7 +51,7 @@ void eraPvxpv(double a[2][3], double b[2][3], double axb[2][3])
    eraPxp(wa[1], wb[0], adxb);
    eraPpp(axbd, adxb, axb[1]);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/pxp.c
+++ b/src/pxp.c
@@ -19,7 +19,7 @@ void eraPxp(double a[3], double b[3], double axb[3])
 **     It is permissible to re-use the same array for any of the
 **     arguments.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -38,7 +38,7 @@ void eraPxp(double a[3], double b[3], double axb[3])
    axb[1] = za*xb - xa*zb;
    axb[2] = xa*yb - ya*xb;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/refco.c
+++ b/src/refco.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraRefco(double phpa, double tc, double rh, double wl,
               double *refa, double *refb)
@@ -149,7 +150,7 @@ void eraRefco(double phpa, double tc, double rh, double wl,
 **
 **     Stone, Ronald C., P.A.S.P. 108, 1051-1058, 1996.
 **
-**  This revision:   2020 August 17
+**  This revision:   2021 February 24
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.

--- a/src/rm2v.c
+++ b/src/rm2v.c
@@ -29,7 +29,7 @@ void eraRm2v(double r[3][3], double w[3])
 **  3) The reference frame rotates clockwise as seen looking along
 **     the rotation vector from the origin.
 **
-**  This revision:  2015 January 30
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -55,7 +55,7 @@ void eraRm2v(double r[3][3], double w[3])
       w[2] = 0.0;
    }
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/rv2m.c
+++ b/src/rv2m.c
@@ -26,7 +26,7 @@ void eraRv2m(double w[3], double r[3][3])
 **  3) The reference frame rotates clockwise as seen looking along the
 **     rotation vector from the origin.
 **
-**  This revision:  2020 August 21
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -62,7 +62,7 @@ void eraRv2m(double w[3], double r[3][3])
    r[2][1] = z*y*f - x*s;
    r[2][2] = z*z*f + c;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/rx.c
+++ b/src/rx.c
@@ -28,7 +28,7 @@ void eraRx(double phi, double r[3][3])
 **         (                               )
 **         (  0   - sin(phi)   + cos(phi)  )
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -54,7 +54,7 @@ void eraRx(double phi, double r[3][3])
    r[2][1] = a21;
    r[2][2] = a22;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/rxp.c
+++ b/src/rxp.c
@@ -21,7 +21,7 @@ void eraRxp(double r[3][3], double p[3], double rp[3])
 **  Called:
 **     eraCp        copy p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -43,7 +43,7 @@ void eraRxp(double r[3][3], double p[3], double rp[3])
 /* Return the result. */
    eraCp(wrp, rp);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/rxpv.c
+++ b/src/rxpv.c
@@ -27,7 +27,7 @@ void eraRxpv(double r[3][3], double pv[2][3], double rpv[2][3])
 **  Called:
 **     eraRxp       product of r-matrix and p-vector
 **
-**  This revision:  2020 September 26
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -36,7 +36,7 @@ void eraRxpv(double r[3][3], double pv[2][3], double rpv[2][3])
    eraRxp(r, pv[0], rpv[0]);
    eraRxp(r, pv[1], rpv[1]);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/rxr.c
+++ b/src/rxr.c
@@ -22,7 +22,7 @@ void eraRxr(double a[3][3], double b[3][3], double atb[3][3])
 **  Called:
 **     eraCr        copy r-matrix
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -43,7 +43,7 @@ void eraRxr(double a[3][3], double b[3][3], double atb[3][3])
    }
    eraCr(wm, atb);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ry.c
+++ b/src/ry.c
@@ -28,7 +28,7 @@ void eraRy(double theta, double r[3][3])
 **         (                                        )
 **         (  + sin(theta)     0      + cos(theta)  )
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -54,7 +54,7 @@ void eraRy(double theta, double r[3][3])
    r[2][1] = a21;
    r[2][2] = a22;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/rz.c
+++ b/src/rz.c
@@ -28,7 +28,7 @@ void eraRz(double psi, double r[3][3])
 **         (                                 )
 **         (       0            0         1  )
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -54,7 +54,7 @@ void eraRz(double psi, double r[3][3])
    r[1][1] = a11;
    r[1][2] = a12;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/s00.c
+++ b/src/s00.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraS00(double date1, double date2, double x, double y)
 /*
@@ -76,7 +77,7 @@ double eraS00(double date1, double date2, double x, double y)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2020 November 4
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -316,6 +317,8 @@ double eraS00(double date1, double date2, double x, double y)
         w5 * t) * t) * t) * t) * t) * ERFA_DAS2R - x*y/2.0;
 
    return s;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/s00a.c
+++ b/src/s00a.c
@@ -69,7 +69,7 @@ double eraS00a(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -88,6 +88,8 @@ double eraS00a(double date1, double date2)
    s = eraS00(date1, date2, x, y);
 
    return s;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/s00b.c
+++ b/src/s00b.c
@@ -69,7 +69,7 @@ double eraS00b(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -88,6 +88,8 @@ double eraS00b(double date1, double date2)
    s = eraS00(date1, date2, x, y);
 
    return s;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/s06.c
+++ b/src/s06.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraS06(double date1, double date2, double x, double y)
 /*
@@ -73,7 +74,7 @@ double eraS06(double date1, double date2, double x, double y)
 **     McCarthy, D.D., Petit, G. (eds.) 2004, IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG
 **
-**  This revision:  2019 June 23
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -313,6 +314,8 @@ double eraS06(double date1, double date2, double x, double y)
         w5 * t) * t) * t) * t) * t) * ERFA_DAS2R - x*y/2.0;
 
    return s;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/s06a.c
+++ b/src/s06a.c
@@ -71,7 +71,7 @@ double eraS06a(double date1, double date2)
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -90,6 +90,8 @@ double eraS06a(double date1, double date2)
    s = eraS06(date1, date2, x, y);
 
    return s;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/s2c.c
+++ b/src/s2c.c
@@ -15,7 +15,7 @@ void eraS2c(double theta, double phi, double c[3])
 **  Returned:
 **     c        double[3]    direction cosines
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -29,7 +29,7 @@ void eraS2c(double theta, double phi, double c[3])
    c[1] = sin(theta) * cp;
    c[2] = sin(phi);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/s2p.c
+++ b/src/s2p.c
@@ -20,7 +20,7 @@ void eraS2p(double theta, double phi, double r, double p[3])
 **     eraS2c       spherical coordinates to unit vector
 **     eraSxp       multiply p-vector by scalar
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -32,7 +32,7 @@ void eraS2p(double theta, double phi, double r, double p[3])
    eraS2c(theta, phi, u);
    eraSxp(r, u, p);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/s2pv.c
+++ b/src/s2pv.c
@@ -21,7 +21,7 @@ void eraS2pv(double theta, double phi, double r,
 **  Returned:
 **     pv       double[2][3]    pv-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -47,7 +47,7 @@ void eraS2pv(double theta, double phi, double r,
    pv[1][1] =  x*td - w*st;
    pv[1][2] = rpd*cp + sp*rd;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/s2xpv.c
+++ b/src/s2xpv.c
@@ -22,7 +22,7 @@ void eraS2xpv(double s1, double s2, double pv[2][3], double spv[2][3])
 **  Called:
 **     eraSxp       multiply p-vector by scalar
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -31,7 +31,7 @@ void eraS2xpv(double s1, double s2, double pv[2][3], double spv[2][3])
    eraSxp(s1, pv[0], spv[0]);
    eraSxp(s2, pv[1], spv[1]);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/sepp.c
+++ b/src/sepp.c
@@ -30,7 +30,7 @@ double eraSepp(double a[3], double b[3])
 **     eraPm        modulus of p-vector
 **     eraPdp       scalar product of two p-vectors
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -50,6 +50,8 @@ double eraSepp(double a[3], double b[3])
    s = ((ss != 0.0) || (cs != 0.0)) ? atan2(ss, cs) : 0.0;
 
    return s;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/seps.c
+++ b/src/seps.c
@@ -21,7 +21,7 @@ double eraSeps(double al, double ap, double bl, double bp)
 **     eraS2c       spherical coordinates to unit vector
 **     eraSepp      angular separation between two p-vectors
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -38,6 +38,8 @@ double eraSeps(double al, double ap, double bl, double bp)
    s = eraSepp(ac, bc);
 
    return s;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/sp00.c
+++ b/src/sp00.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 double eraSp00(double date1, double date2)
 /*
@@ -47,7 +48,7 @@ double eraSp00(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -63,6 +64,8 @@ double eraSp00(double date1, double date2)
    sp = -47e-6 * t * ERFA_DAS2R;
 
    return sp;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/starpm.c
+++ b/src/starpm.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraStarpm(double ra1, double dec1,
               double pmr1, double pmd1, double px1, double rv1,
@@ -106,7 +107,7 @@ int eraStarpm(double ra1, double dec1,
 **     eraPdp       scalar product of two p-vectors
 **     eraPvstar    space motion pv-vector to star catalog data
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -150,6 +151,8 @@ int eraStarpm(double ra1, double dec1,
    j = (j2 == 0) ? j1 : -1;
 
    return j;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/starpv.c
+++ b/src/starpv.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraStarpv(double ra, double dec,
               double pmr, double pmd, double px, double rv,
@@ -113,7 +114,7 @@ int eraStarpv(double ra, double dec,
 **
 **     Stumpff, P., 1985, Astron.Astrophys. 144, 232-240.
 **
-**  This revision:  2017 March 16
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -210,6 +211,8 @@ int eraStarpv(double ra, double dec,
 
 /* Return the status. */
    return iwarn;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/sxp.c
+++ b/src/sxp.c
@@ -18,7 +18,7 @@ void eraSxp(double s, double p[3], double sp[3])
 **  Note:
 **     It is permissible for p and sp to be the same array.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -28,7 +28,7 @@ void eraSxp(double s, double p[3], double sp[3])
    sp[1] = s * p[1];
    sp[2] = s * p[2];
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/sxpv.c
+++ b/src/sxpv.c
@@ -21,7 +21,7 @@ void eraSxpv(double s, double pv[2][3], double spv[2][3])
 **  Called:
 **     eraS2xpv     multiply pv-vector by two scalars
 **
-**  This revision:  2020 August 25
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -29,7 +29,7 @@ void eraSxpv(double s, double pv[2][3], double spv[2][3])
 {
    eraS2xpv(s, s, pv, spv);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/t_erfa_c.c
+++ b/src/t_erfa_c.c
@@ -1,5 +1,6 @@
-#include <stdio.h>
 #include <erfa.h>
+#include "erfam.h"
+#include <stdio.h>
 
 static int verbose = 0;
 
@@ -17,7 +18,7 @@ static int verbose = 0;
 **
 **  All messages go to stdout.
 **
-**  This revision:  2021 January 5
+**  This revision:  2021 April 18
 **
 */
 
@@ -1138,6 +1139,79 @@ static void t_apio13(int *status)
    vvd(astrom.refb, -0.2361408314943696227e-6, 1e-18,
                     "eraApio13", "refb", status);
    viv(j, 0, "eraApio13", "j", status);
+
+}
+
+static void t_atcc13(int *status)
+/*
+**  - - - - - - - - -
+**   t _ a t c c 1 3
+**  - - - - - - - - -
+**
+**  Test eraAtcc13 function.
+**
+**  Returned:
+**     status    int         FALSE = success, TRUE = fail
+**
+**  Called:  eraAtcc13, vvd
+**
+**  This revision:  2021 April 18
+*/
+{
+   double rc, dc, pr, pd, px, rv, date1, date2, ra, da;
+
+
+   rc = 2.71;
+   dc = 0.174;
+   pr = 1e-5;
+   pd = 5e-6;
+   px = 0.1;
+   rv = 55.0;
+   date1 = 2456165.5;
+   date2 = 0.401182685;
+
+   eraAtcc13(rc, dc, pr, pd, px, rv, date1, date2, &ra, &da);
+
+   vvd(ra,  2.710126504531372384, 1e-12,
+           "eraAtcc13", "ra", status);
+   vvd(da, 0.1740632537628350152, 1e-12,
+           "eraAtcc13", "da", status);
+
+}
+
+static void t_atccq(int *status)
+/*
+**  - - - - - - - -
+**   t _ a t c c q
+**  - - - - - - - -
+**
+**  Test eraAtccq function.
+**
+**  Returned:
+**     status    int         FALSE = success, TRUE = fail
+**
+**  Called:  eraApcc13, eraAtccq, vvd
+**
+**  This revision:  2021 April 18
+*/
+{
+   double date1, date2, eo, rc, dc, pr, pd, px, rv, ra, da;
+   eraASTROM astrom;
+
+   date1 = 2456165.5;
+   date2 = 0.401182685;
+   eraApci13(date1, date2, &astrom, &eo);
+   rc = 2.71;
+   dc = 0.174;
+   pr = 1e-5;
+   pd = 5e-6;
+   px = 0.1;
+   rv = 55.0;
+
+   eraAtccq(rc, dc, pr, pd, px, rv, &astrom, &ra, &da);
+
+   vvd(ra, 2.710126504531372384, 1e-12, "eraAtccq", "ra", status);
+   vvd(da, 0.1740632537628350152, 1e-12, "eraAtccq", "da", status);
 
 }
 
@@ -5269,6 +5343,43 @@ static void t_ltpequ(int *status)
        "eraLtpequ", "veq2", status);
    vvd(veq[2], 0.9118552442250819624, 1e-14,
        "eraLtpequ", "veq3", status);
+
+}
+
+static void t_moon98(int *status)
+/*
+**  - - - - - - - - -
+**   t _ m o o n 9 8
+**  - - - - - - - - -
+**
+**  Test eraMoon98 function.
+**
+**  Returned:
+**     status    int         FALSE = success, TRUE = fail
+**
+**  Called:  eraMoon98, vvd, viv
+**
+**  This revision:  2021 April 12
+*/
+{
+   double pv[2][3];
+
+
+   eraMoon98(2400000.5, 43999.9, pv);
+
+   vvd(pv[0][0], -0.2601295959971044180e-2, 1e-11,
+       "eraMoon98", "x 4", status);
+   vvd(pv[0][1], 0.6139750944302742189e-3, 1e-11,
+       "eraMoon98", "y 4", status);
+   vvd(pv[0][2], 0.2640794528229828909e-3, 1e-11,
+       "eraMoon98", "z 4", status);
+
+   vvd(pv[1][0], -0.1244321506649895021e-3, 1e-11,
+       "eraMoon98", "xd 4", status);
+   vvd(pv[1][1], -0.5219076942678119398e-3, 1e-11,
+       "eraMoon98", "yd 4", status);
+   vvd(pv[1][2], -0.1716132214378462047e-3, 1e-11,
+       "eraMoon98", "zd 4", status);
 
 }
 
@@ -9883,7 +9994,7 @@ int main(int argc, char *argv[])
 **   m a i n
 **  - - - - -
 **
-**  This revision:  2017 October 21
+**  This revision:  2021 April 18
 */
 {
    int status;
@@ -9918,6 +10029,8 @@ int main(int argc, char *argv[])
    t_aper13(&status);
    t_apio(&status);
    t_apio13(&status);
+   t_atcc13(&status);
+   t_atccq(&status);
    t_atci13(&status);
    t_atciq(&status);
    t_atciqn(&status);
@@ -10030,6 +10143,7 @@ int main(int argc, char *argv[])
    t_ltpb(&status);
    t_ltpecl(&status);
    t_ltpequ(&status);
+   t_moon98(&status);
    t_num00a(&status);
    t_num00b(&status);
    t_num06a(&status);

--- a/src/taitt.c
+++ b/src/taitt.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraTaitt(double tai1, double tai2, double *tt1, double *tt2)
 /*
@@ -33,7 +34,7 @@ int eraTaitt(double tai1, double tai2, double *tt1, double *tt2)
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -55,6 +56,8 @@ int eraTaitt(double tai1, double tai2, double *tt1, double *tt2)
 
 /* Status (always OK). */
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/taiut1.c
+++ b/src/taiut1.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraTaiut1(double tai1, double tai2, double dta,
               double *ut11, double *ut12)
@@ -35,7 +36,7 @@ int eraTaiut1(double tai1, double tai2, double dta,
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -56,6 +57,8 @@ int eraTaiut1(double tai1, double tai2, double dta,
 
 /* Status (always OK). */
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/taiutc.c
+++ b/src/taiutc.c
@@ -56,7 +56,7 @@ int eraTaiutc(double tai1, double tai2, double *utc1, double *utc2)
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -104,6 +104,8 @@ int eraTaiutc(double tai1, double tai2, double *utc1, double *utc2)
 
 /* Status. */
    return j;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/tcbtdb.c
+++ b/src/tcbtdb.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraTcbtdb(double tcb1, double tcb2, double *tdb1, double *tdb2)
 /*
@@ -47,7 +48,7 @@ int eraTcbtdb(double tcb1, double tcb2, double *tdb1, double *tdb2)
 **
 **     IAU 2006 Resolution B3
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -77,6 +78,8 @@ int eraTcbtdb(double tcb1, double tcb2, double *tdb1, double *tdb2)
 
 /* Status (always OK). */
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/tcgtt.c
+++ b/src/tcgtt.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraTcgtt(double tcg1, double tcg2, double *tt1, double *tt2)
 /*
@@ -32,7 +33,7 @@ int eraTcgtt(double tcg1, double tcg2, double *tt1, double *tt2)
 **
 **     IAU 2000 Resolution B1.9
 **
-**  This revision:  2020 October 23
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -54,6 +55,8 @@ int eraTcgtt(double tcg1, double tcg2, double *tt1, double *tt2)
 
 /* OK status. */
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/tdbtcb.c
+++ b/src/tdbtcb.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraTdbtcb(double tdb1, double tdb2, double *tcb1, double *tcb2)
 /*
@@ -47,7 +48,7 @@ int eraTdbtcb(double tdb1, double tdb2, double *tcb1, double *tcb2)
 **
 **     IAU 2006 Resolution B3
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -82,6 +83,8 @@ int eraTdbtcb(double tdb1, double tdb2, double *tcb1, double *tcb2)
 
 /* Status (always OK). */
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/tdbtt.c
+++ b/src/tdbtt.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraTdbtt(double tdb1, double tdb2, double dtr,
              double *tt1, double *tt2 )
@@ -45,7 +46,7 @@ int eraTdbtt(double tdb1, double tdb2, double dtr,
 **
 **     IAU 2006 Resolution 3
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -66,6 +67,8 @@ int eraTdbtt(double tdb1, double tdb2, double dtr,
 
 /* Status (always OK). */
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/tf2d.c
+++ b/src/tf2d.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 #include <stdlib.h>
 
 int eraTf2d(char s, int ihour, int imin, double sec, double *days)
@@ -34,7 +35,7 @@ int eraTf2d(char s, int ihour, int imin, double sec, double *days)
 **  3)  If there are multiple errors, the status value reflects only the
 **      first, the smallest taking precedence.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -52,6 +53,8 @@ int eraTf2d(char s, int ihour, int imin, double sec, double *days)
    if ( imin < 0 || imin > 59 ) return 2;
    if ( sec < 0.0 || sec >= 60.0 ) return 3;
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/tr.c
+++ b/src/tr.c
@@ -20,7 +20,7 @@ void eraTr(double r[3][3], double rt[3][3])
 **  Called:
 **     eraCr        copy r-matrix
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -37,7 +37,7 @@ void eraTr(double r[3][3], double rt[3][3])
    }
    eraCr(wm, rt);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/trxp.c
+++ b/src/trxp.c
@@ -22,7 +22,7 @@ void eraTrxp(double r[3][3], double p[3], double trp[3])
 **     eraTr        transpose r-matrix
 **     eraRxp       product of r-matrix and p-vector
 **
-**  This revision:  2020 May 24
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -37,7 +37,7 @@ void eraTrxp(double r[3][3], double p[3], double trp[3])
 /* Matrix tr * vector p -> vector trp. */
    eraRxp(tr, p, trp);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/trxpv.c
+++ b/src/trxpv.c
@@ -28,7 +28,7 @@ void eraTrxpv(double r[3][3], double pv[2][3], double trpv[2][3])
 **     eraTr        transpose r-matrix
 **     eraRxpv      product of r-matrix and pv-vector
 **
-**  This revision:  2020 September 26
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -43,7 +43,7 @@ void eraTrxpv(double r[3][3], double pv[2][3], double trpv[2][3])
 /* Matrix tr * vector pv -> vector trpv. */
    eraRxpv(tr, pv, trpv);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/tttai.c
+++ b/src/tttai.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraTttai(double tt1, double tt2, double *tai1, double *tai2)
 /*
@@ -33,7 +34,7 @@ int eraTttai(double tt1, double tt2, double *tai1, double *tai2)
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -55,6 +56,8 @@ int eraTttai(double tt1, double tt2, double *tai1, double *tai2)
 
 /* Status (always OK). */
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/tttcg.c
+++ b/src/tttcg.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraTttcg(double tt1, double tt2, double *tcg1, double *tcg2)
 /*
@@ -32,7 +33,7 @@ int eraTttcg(double tt1, double tt2, double *tcg1, double *tcg2)
 **
 **     IAU 2000 Resolution B1.9
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -57,6 +58,8 @@ int eraTttcg(double tt1, double tt2, double *tcg1, double *tcg2)
 
 /* Status (always OK). */
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/tttdb.c
+++ b/src/tttdb.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraTttdb(double tt1, double tt2, double dtr,
              double *tdb1, double *tdb2)
@@ -45,7 +46,7 @@ int eraTttdb(double tt1, double tt2, double dtr,
 **
 **     IAU 2006 Resolution 3
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -66,6 +67,8 @@ int eraTttdb(double tt1, double tt2, double dtr,
 
 /* Status (always OK). */
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ttut1.c
+++ b/src/ttut1.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraTtut1(double tt1, double tt2, double dt,
              double *ut11, double *ut12)
@@ -34,7 +35,7 @@ int eraTtut1(double tt1, double tt2, double dt,
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -55,6 +56,8 @@ int eraTtut1(double tt1, double tt2, double dt,
 
 /* Status (always OK). */
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ut1tai.c
+++ b/src/ut1tai.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraUt1tai(double ut11, double ut12, double dta,
               double *tai1, double *tai2)
@@ -35,7 +36,7 @@ int eraUt1tai(double ut11, double ut12, double dta,
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -56,6 +57,8 @@ int eraUt1tai(double ut11, double ut12, double dta,
 
 /* Status (always OK). */
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ut1tt.c
+++ b/src/ut1tt.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraUt1tt(double ut11, double ut12, double dt,
              double *tt1, double *tt2)
@@ -34,7 +35,7 @@ int eraUt1tt(double ut11, double ut12, double dt,
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -55,6 +56,8 @@ int eraUt1tt(double ut11, double ut12, double dt,
 
 /* Status (always OK). */
    return 0;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/ut1utc.c
+++ b/src/ut1utc.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraUt1utc(double ut11, double ut12, double dut1,
               double *utc1, double *utc2)
@@ -62,7 +63,7 @@ int eraUt1utc(double ut11, double ut12, double dut1,
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2020 October 25
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -138,6 +139,8 @@ int eraUt1utc(double ut11, double ut12, double dut1,
 
 /* Status. */
    return js;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/utctai.c
+++ b/src/utctai.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 int eraUtctai(double utc1, double utc2, double *tai1, double *tai2)
 /*
@@ -58,7 +59,7 @@ int eraUtctai(double utc1, double utc2, double *tai1, double *tai2)
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -122,6 +123,8 @@ int eraUtctai(double utc1, double utc2, double *tai1, double *tai2)
 
 /* Status. */
    return j;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/utcut1.c
+++ b/src/utcut1.c
@@ -63,7 +63,7 @@ int eraUtcut1(double utc1, double utc2, double dut1,
 **     eraUtctai    UTC to TAI
 **     eraTaiut1    TAI to UT1
 **
-**  This revision:  2013 August 12
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -92,6 +92,8 @@ int eraUtcut1(double utc1, double utc2, double dut1,
 
 /* Status. */
    return js;
+
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/xy06.c
+++ b/src/xy06.c
@@ -1,4 +1,5 @@
 #include "erfa.h"
+#include "erfam.h"
 
 void eraXy06(double date1, double date2, double *x, double *y)
 /*
@@ -85,7 +86,7 @@ void eraXy06(double date1, double date2, double *x, double *y)
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2019 June 23
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -2702,7 +2703,7 @@ void eraXy06(double date1, double date2, double *x, double *y)
    *x = ERFA_DAS2R * (xypr[0] + (xyls[0] + xypl[0]) / 1e6);
    *y = ERFA_DAS2R * (xypr[1] + (xyls[1] + xypl[1]) / 1e6);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/xys00a.c
+++ b/src/xys00a.c
@@ -59,7 +59,7 @@ void eraXys00a(double date1, double date2,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2019 November 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -77,7 +77,7 @@ void eraXys00a(double date1, double date2,
 /* Obtain s. */
    *s = eraS00(date1, date2, *x, *y);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/xys00b.c
+++ b/src/xys00b.c
@@ -59,7 +59,7 @@ void eraXys00b(double date1, double date2,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2020 December 4
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -77,7 +77,7 @@ void eraXys00b(double date1, double date2,
 /* Obtain s. */
    *s = eraS00(date1, date2, *x, *y);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/xys06a.c
+++ b/src/xys06a.c
@@ -59,7 +59,7 @@ void eraXys06a(double date1, double date2,
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2020 December 4
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -77,7 +77,7 @@ void eraXys06a(double date1, double date2,
 /* Obtain s. */
    *s = eraS06(date1, date2, *x, *y);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/zp.c
+++ b/src/zp.c
@@ -11,7 +11,7 @@ void eraZp(double p[3])
 **  Returned:
 **     p        double[3]      zero p-vector
 **
-**  This revision:  2020 August 25
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -21,7 +21,7 @@ void eraZp(double p[3])
    p[1] = 0.0;
    p[2] = 0.0;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/zpv.c
+++ b/src/zpv.c
@@ -14,7 +14,7 @@ void eraZpv(double pv[2][3])
 **  Called:
 **     eraZp        zero p-vector
 **
-**  This revision:  2020 August 25
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -23,7 +23,7 @@ void eraZpv(double pv[2][3])
    eraZp(pv[0]);
    eraZp(pv[1]);
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------

--- a/src/zr.c
+++ b/src/zr.c
@@ -11,7 +11,7 @@ void eraZr(double r[3][3])
 **  Returned:
 **     r        double[3][3]    r-matrix
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
 **  Copyright (C) 2013-2021, NumFOCUS Foundation.
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
@@ -27,7 +27,7 @@ void eraZr(double r[3][3])
    r[2][1] = 0.0;
    r[2][2] = 0.0;
 
-   return;
+/* Finished. */
 
 }
 /*----------------------------------------------------------------------


### PR DESCRIPTION
A new SOFA release is out. Things run well, but I'd appreciate a check on the new version numbers. For this purpose, SOFA adds 3 new functions, so definitely not just a bugfix, but it also does:

> A rearrangement of the ANSI C header files sofam.h and sofa.h has been implemented. The consequence of this is that an explicit #include "sofam.h" has been added to many of the SOFA functions. Thus developers of applications that use constants from sofa.h will now need to include an explicit #include. Further explanation is given in the changes.pdf files included in the distributions.

Even though strictly no symbols changed, since this means people may have to change source code to explicitly include `erfam.h` if they use the ERFA library, I've interpreted this as implying we should go to a new major version number, i.e., 2.0.0. Does this make sense? (see also the change to `README.rst` in the second commit: https://github.com/liberfa/erfa/pull/84/commits/3939e0dab3518770060a563c7ea6f178c9554d6a)

For the library proper, the new functions imply a new revision, but it is backwards compatible, so I increased age as well.

p.s. Would have been nice to go to ERFA 1.8 for SOFA 18, but o well!