### PR TITLE
Port build system to Meson

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -39,3 +39,37 @@ jobs:
       run: make check
     - name: make distcheck
       run: make distcheck
+
+  tests-meson:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux (with gcc and meson)
+            os: ubuntu-latest
+
+          - name: MacOS (with clang and meson)
+            os: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Install dependencies
+      run: |
+        if [ "$RUNNER_OS" = Linux ]; then
+            sudo apt-get -y install meson ninja-build
+        else
+            brew install meson
+        fi
+
+    - name: configure
+      run: meson setup builddir --fatal-meson-warnings
+    - name: build
+      run: ninja -C builddir
+    - name: check
+      run: meson test -C builddir
+    - name: distcheck
+      run: meson dist -C builddir

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -73,3 +73,22 @@ jobs:
       run: meson test -C builddir
     - name: distcheck
       run: meson dist -C builddir
+
+  Windows-meson:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: pip install --pre meson ninja
+    - uses: ilammy/msvc-dev-cmd@v1
+    - name: configure
+      run: meson setup builddir --fatal-meson-warnings
+    - name: build
+      run: ninja -C builddir
+    - name: check
+      run: meson test -C builddir
+    - name: distcheck
+      run: meson dist -C builddir

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -85,7 +85,7 @@ jobs:
       run: pip install --pre meson ninja
     - uses: ilammy/msvc-dev-cmd@v1
     - name: configure
-      run: meson setup builddir --fatal-meson-warnings
+      run: meson setup builddir --fatal-meson-warnings -Ddefault_library=static
     - name: build
       run: ninja -C builddir
     - name: check

--- a/README.rst
+++ b/README.rst
@@ -121,27 +121,29 @@ Building and installing ERFA
 ----------------------------
 
 To build and install a released version of ERFA in your OS's standard
-location, simply do::
+location, you need to install `meson <https://mesonbuild.com/Getting-meson.html>`_
+and `ninja <https://ninja-build.org/>`_. On Debian-based OSes, these
+can be installed with ``apt install meson``.
 
-    ./configure
-    make
-    make install
+Then, simply do::
+
+    meson setup builddir/
+    ninja -C builddir/
+    meson install -C builddir/
 
 If you want to run the tests to make sure ERFA built correctly, before
 installing do::
 
-    make check
+    meson test -C builddir/
 
 
 For developers
 ^^^^^^^^^^^^^^
 
-If you are using a developer version from github, you will need to first do
-``./bootstrap.sh`` before the above commands. This requires ``autoconf`` and
-``libtool``.
-
 If you wish to build against the ERFA static library without installing, you
-will find it in ``$ERFAROOT/src/.libs/liberfa.a`` after running ``make``.
+can add ``$PWD/builddir/meson-uninstalled/`` to the ``$PKG_CONFIG_PATH``
+variable. Other projects will then be able to pick up and link to the uninstalled
+dependency using pkg-config as normal.
 
 Creating a single-file version of the source code
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -22,13 +22,13 @@ places no contraints on who has permissions to submit code changes.
   repository`_ in its own directory.  That will create a directory called `erfa`
   inside the `erfa-fetch` directory, and   you should copy its contents to the
   `src` directory of `erfa`.  Add any new C files or header files added by SOFA
-  to ``src/Makefile.am``, as appropriate.
+  to ``src/meson.build``, as appropriate.
 
 * Use ``git diff`` in `erfa` to inspect the changes, ensuring that you are not
   overwriting *intentional* changes between SOFA and ERFA (the README from the
   previous version is generally your friend here.)
 
-* Update the ``SOFA_VERSION`` macro in ``configure.ac`` to reflect the new SOFA
+* Update the ``SOFA_VERSION`` define in ``meson.build`` to reflect the new SOFA
   version.
 
 * Update the SOFA version mentioned in `README.rst` to reflect what's now in, as
@@ -55,12 +55,12 @@ Releasing ERFA
 These steps should be done by a maintainer, as they require specific Github
 permissions.
 
-* Update the version number in the `AC_INIT` macro of `configure.ac` to
+* Update the version number in the `project()` version field of `meson.build` to
   the version number you are about to release, and also  Follow the instructions
   in the `Version numbering` "Package version number" section below.
 
-* Update the version info of the shared library in the `ERFA_LIB_VERSION_INFO`
-  macro of `configure.ac`. Follow the instructions in `Version numbering`
+* Update the version info of the shared library in the `libtool_version`
+  variable of `meson.build`. Follow the instructions in `Version numbering`
   "Shared library version info" section below.
 
 * Update the `README.rst` to reference the version you filled in above for
@@ -71,26 +71,21 @@ permissions.
 * Commit these changes using ``git commit``, with a commit message like
   ``Preparing release v0.0.1``.
 
-* Run ``git clean -fxd`` to be sure you are building in a clean environment.
-
-* Run ``./bootstrap.sh``: you need `automake`, `autoconf` and `libtool`
-  installed.  If no errors appear, this will create a new `./configure`
-  file.
-
-* Run ``./configure``, which should create a `Makefile` in the top level
-  directory and in ./src, as well as a `config.h` file in the top level.
+* Run ``meson setup builddir``: you need `meson` installed.  If no errors appear,
+  this will create a `build.ninja` file in the build directory, as well as a
+  `config.h`.
   To avoid possible trouble, check that in the latter, `PACKAGE_VERSION`
   is set correctly.
 
-* Run ``make check``, which will build the library and run the tests -
+* Run ``meson test -C builddir``, which will build the library and run the tests -
   make sure they pass before proceeding. (This is already done by continuous
   integration in Github so it really *should* pass, but better to be safe than
   sorry!)
 
-* Run ``make distcheck``: this creates the distribution tarball,
+* Run ``meson dist -C builddir``: this creates the distribution tarball,
   unpackages it and runs the check inside the untarred directory.
   The resulting tarball will be named e.g., `erfa-0.0.1.tar.gz` and
-  will be placed in the working directory.
+  will be placed in `builddir/meson-dist` (its filename will be printed out as well).
 
 * Tag the current commit with the version number.  A signed tag is preferred if
   you have an a signing key (e.g., do ``git tag -s v0.0.1``).
@@ -166,7 +161,7 @@ If the version is given in the form MAJOR.MINOR.PATCH, then
         you are either fixing a bug or making other improvements. Increase
         patch by one and do not change the others.
 
-Change the version number in `README.rst` and the `AC_INIT` macro.
+Change the version number in `README.rst` and the `project()` version argument.
 
 Shared library version info
 ---------------------------
@@ -184,7 +179,7 @@ Again, the release manager has to review the relevant information:
   * relevant bug reports in the github project page
 
 The shared library version info is stored in three numbers called *current*,
-*revision* and *age*. These numbers appear in the macro `ERFA_LIB_VERSION_INFO`
+*revision* and *age*. These numbers appear in the variable `libtool_version`
 in the mentioned order.
 
 If the version is given in the form CURRENT,REVISION,AGE then
@@ -200,7 +195,7 @@ If the version is given in the form CURRENT,REVISION,AGE then
   * else
        do not change the version info (c,r,a -> c,r,a)
 
-Change the version info in `ERFA_LIB_VERSION_INFO`
+Change the version info in `libtool_version`
 
 Examples
 ---------

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,41 @@
+project(
+    'erfa', 'c',
+    version: '2.0.0',
+    meson_version: '>=0.46.0',
+)
+
+cc = meson.get_compiler('c')
+confdata = configuration_data()
+
+# The historic versions use libtool-compatible versioning.
+# This uses some gnarly math to define ABI versions, which we replicate here.
+# The general formula is:
+#   libtool: C:R:A
+#   -soname: (C - A).A.R
+libtool_version = [9, 0, 8]
+soversion = '@0@.@1@.@2@'.format(
+    libtool_version[0] - libtool_version[2],
+    libtool_version[2],
+    libtool_version[1],
+)
+
+# API versions
+version = meson.project_version().split('.')
+confdata.set_quoted('PACKAGE_VERSION', meson.project_version())
+confdata.set('PACKAGE_VERSION_MAJOR', version[0])
+confdata.set('PACKAGE_VERSION_MINOR', version[1])
+confdata.set('PACKAGE_VERSION_MICRO', version[2])
+
+confdata.set_quoted('SOFA_VERSION', '20210512')
+
+
+libm = cc.find_library('m', required: false)
+
+subdir('src')
+
+import('pkgconfig').generate(
+    liberfa,
+    filebase: 'erfa',
+    name: 'Erfa',
+    description: 'Essential Routines for Fundamental Astronomy',
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,51 @@
+configure_file(output: 'config.h', configuration: confdata)
+add_project_arguments('-DHAVE_CONFIG_H', language: 'c')
+
+liberfa = library(
+    'erfa',
+    'a2af.c', 'a2tf.c', 'ab.c', 'ae2hd.c', 'af2a.c', 'anp.c', 'anpm.c', 'apcg13.c',
+    'apcg.c', 'apci13.c', 'apci.c', 'apco13.c', 'apco.c', 'apcs13.c', 'apcs.c', 'aper13.c',
+    'aper.c', 'apio13.c', 'apio.c', 'atcc13.c', 'atccq.c',
+    'atci13.c', 'atciq.c', 'atciqn.c', 'atciqz.c', 'atco13.c',
+    'atic13.c', 'aticq.c', 'aticqn.c', 'atio13.c', 'atioq.c', 'atoc13.c', 'atoi13.c', 'atoiq.c',
+    'bi00.c', 'bp00.c', 'bp06.c', 'bpn2xy.c', 'c2i00a.c', 'c2i00b.c', 'c2i06a.c', 'c2ibpn.c',
+    'c2ixy.c', 'c2ixys.c', 'c2s.c', 'c2t00a.c', 'c2t00b.c', 'c2t06a.c', 'c2tcio.c', 'c2teqx.c',
+    'c2tpe.c', 'c2txy.c', 'cal2jd.c', 'cp.c', 'cpv.c', 'cr.c', 'd2dtf.c', 'd2tf.c', 'dat.c', 'dtdb.c',
+    'dtf2d.c', 'eceq06.c', 'ee00a.c', 'ee00.c', 'eect00.c', 'eo06a.c', 'epb2jd.c', 'epj2jd.c', 'epv00.c',
+    'eqeq94.c', 'ecm06.c', 'ee00b.c', 'ee06a.c', 'eform.c', 'eors.c', 'epb.c', 'epj.c', 'eqec06.c',
+    'era00.c', 'fad03.c', 'fae03.c', 'faf03.c', 'faju03.c', 'fal03.c', 'falp03.c', 'fama03.c',
+    'fame03.c', 'fane03.c', 'faom03.c', 'fapa03.c', 'fasa03.c', 'faur03.c', 'fave03.c',
+    'fk425.c', 'fk45z.c', 'fk524.c', 'fk54z.c',
+    'fk52h.c', 'fk5hip.c', 'fk5hz.c', 'fw2m.c', 'fw2xy.c', 'g2icrs.c', 'gc2gd.c', 'gc2gde.c', 'gd2gc.c',
+    'gd2gce.c', 'gmst00.c', 'gmst06.c', 'gmst82.c', 'gst00a.c', 'gst00b.c', 'gst06a.c',
+    'gst06.c', 'gst94.c', 'hd2ae.c', 'hd2pa.c', 'h2fk5.c', 'hfk5z.c', 'icrs2g.c', 'ir.c',
+    'jd2cal.c', 'jdcalf.c', 'ld.c',
+    'ldn.c', 'ldsun.c', 'lteceq.c', 'ltecm.c', 'lteqec.c', 'ltpb.c', 'ltp.c', 'ltpecl.c', 'ltpequ.c',
+    'moon98.c',
+    'num00a.c', 'num00b.c', 'num06a.c', 'numat.c', 'nut00a.c', 'nut00b.c',
+    'nut06a.c', 'nut80.c', 'nutm80.c', 'obl06.c', 'obl80.c', 'p06e.c', 'p2pv.c', 'p2s.c', 'pap.c',
+    'pas.c', 'pb06.c', 'pdp.c', 'pfw06.c', 'plan94.c', 'pmat00.c', 'pmat06.c', 'pmat76.c',
+    'pm.c', 'pmp.c', 'pmpx.c', 'pmsafe.c', 'pn00a.c', 'pn00b.c', 'pn00.c', 'pn06a.c',
+    'pn06.c', 'pn.c', 'pnm00a.c', 'pnm00b.c', 'pnm06a.c', 'pnm80.c', 'pom00.c', 'ppp.c',
+    'ppsp.c', 'pr00.c', 'prec76.c', 'pv2p.c', 'pv2s.c', 'pvdpv.c', 'pvm.c', 'pvmpv.c', 'pvppv.c',
+    'pvstar.c', 'pvtob.c', 'pvu.c', 'pvup.c', 'pvxpv.c', 'pxp.c', 'refco.c', 'rm2v.c', 'rv2m.c',
+    'rx.c', 'rxp.c', 'rxpv.c', 'rxr.c', 'ry.c', 'rz.c', 's00a.c', 's00b.c', 's00.c',
+    's06a.c', 's06.c', 's2c.c', 's2p.c', 's2pv.c', 's2xpv.c', 'sepp.c', 'seps.c', 'sp00.c',
+    'starpm.c', 'starpv.c', 'sxp.c', 'sxpv.c', 'taitt.c', 'taiut1.c', 'taiutc.c', 'tcbtdb.c',
+    'tcgtt.c', 'tdbtcb.c', 'tdbtt.c', 'tf2a.c', 'tf2d.c', 'tpors.c', 'tporv.c', 'tpsts.c',
+    'tpstv.c', 'tpxes.c', 'tpxev.c', 'tr.c', 'trxp.c', 'trxpv.c', 'tttai.c',
+    'tttcg.c', 'tttdb.c', 'ttut1.c', 'ut1tai.c', 'ut1tt.c', 'ut1utc.c', 'utctai.c', 'utcut1.c',
+    'xy06.c', 'xys00a.c', 'xys00b.c', 'xys06a.c', 'zp.c', 'zpv.c', 'zr.c',
+    'erfaversion.c', 'erfadatextra.c',
+    dependencies: libm,
+    version: soversion,
+    install: true,
+)
+
+erfa_dep = declare_dependency(link_with: liberfa, include_directories: '.')
+install_headers('erfa.h', 'erfam.h', 'erfaextra.h', 'erfadatextra.h')
+
+foreach t: ['t_erfa_c', 't_erfa_c_extra']
+    exe = executable(t, t+'.c', link_with: liberfa)
+    test(t, exe)
+endforeach


### PR DESCRIPTION
Prerequisite for porting pyerfa to Meson in https://github.com/liberfa/pyerfa/issues/91

Removing the autotools build can be done as well, if interested, implemented in eli-schwartz@0695ad204b5b58f06add71a4f908480bafb344c9 for an overall diffstat of:

```
 .gitignore        | 24 ------------------------
 Makefile.am       | 10 ----------
 RELEASE.rst       | 33 ++++++++++++++-------------------
 bootstrap.sh      |  8 --------
 configure.ac      | 32 --------------------------------
 erfa.pc.in        | 11 -----------
 m4/erfa-numver.m4 | 45 ---------------------------------------------
 meson.build       | 41 +++++++++++++++++++++++++++++++++++++++++
 src/Makefile.am   | 54 ------------------------------------------------------
 src/meson.build   | 51 +++++++++++++++++++++++++++++++++++++++++++++++++++
 10 files changed, 106 insertions(+), 203 deletions(-)
 delete mode 100644 .gitignore
 delete mode 100644 Makefile.am
 delete mode 100755 bootstrap.sh
 delete mode 100644 configure.ac
 delete mode 100644 erfa.pc.in
 delete mode 100644 m4/erfa-numver.m4
 create mode 100644 meson.build
 delete mode 100644 src/Makefile.am
 create mode 100644 src/meson.build
```