### PR TITLE
BLD: fix type safety of version numbers (fix building on some systems)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,7 +20,7 @@ soversion = '@0@.@1@.@2@'.format(
 )
 
 # API versions
-version = meson.project_version().split('.')
+version = tuple(int(_) for _ in meson.project_version().split('.'))
 confdata.set_quoted('PACKAGE_VERSION', meson.project_version())
 confdata.set('PACKAGE_VERSION_MAJOR', version[0])
 confdata.set('PACKAGE_VERSION_MINOR', version[1])


### PR DESCRIPTION
This fixes compilation of pyerfa on my system (MacOS AMD64) as reported in https://github.com/liberfa/pyerfa/issues/141
However it's not clear to me what changed recently that made this patch (apparently) necessary. It's still possible that the change was specific to my setup, but I figure this patch is probably acceptable regardless.