### PR TITLE
Fix conflict when importing C math library math.h

### DIFF
--- a/src/erfa.h
+++ b/src/erfa.h
@@ -12,7 +12,7 @@
 **  Derived, with permission, from the SOFA library.  See notes at end of file.
 */
 
-#include "math.h"
+#include <math.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
At the moment the C header math library is imported using quotes. However, if the project already has a math.h file is imported before the math.h C library file, having a conflict. Is it possible to import it using <>?

Thank you!