### PR TITLE
Fix a typo in a test function

### DIFF
--- a/src/t_erfa_c.c
+++ b/src/t_erfa_c.c
@@ -6412,7 +6412,7 @@ static void t_pmsafe(int *status)
             "eraPmsafe", "px2", status);
    vvd(rv2, 10.38468380293920069, 1e-10,
             "eraPmsafe", "rv2", status);
-   viv ( j, 0, "eraPmsafe", "j", status);
+   viv( j, 0, "eraPmsafe", "j", status);
 
 }
 


### PR DESCRIPTION
One of the things that happens when `pyerfa` is built is that the tests in `t_erfa_c.c` are converted into `pytest` tests, but an extraneous whitespace in a single line is needlessly complicating that conversion because that line cannot be processed by calling `line.removeprefix("viv(")` in Python.