### PR TITLE
Clean up  README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,11 +166,6 @@ the ERFA source code into just two files: a ``erfa.c`` source file, and an
 If possible, however, it is recommended that you provide an option to use any
 copy of the ERFA library that is already installed on the system.
 
-Travis build status
--------------------
-.. image:: https://travis-ci.org/liberfa/erfa.png
-    :target: https://travis-ci.org/liberfa/erfa
-
 .. _erfa-fetch repository: https://github.com/liberfa/erfa-fetch
 
 Cite As

--- a/README.rst
+++ b/README.rst
@@ -151,23 +151,6 @@ can add ``$PWD/builddir/meson-uninstalled/`` to the ``$PKG_CONFIG_PATH``
 variable. Other projects will then be able to pick up and link to the uninstalled
 dependency using pkg-config as normal.
 
-Creating a single-file version of the source code
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Alternatively, if you wish to bundle the ERFA source code with a separate
-package, you can use the ``source_flattener.py`` script from the
-`erfa-fetch repository`_ to combine
-the ERFA source code into just two files: a ``erfa.c`` source file, and an
-``erfa.h`` include file.  You should run this script like this::
-
-    cd /path/to/erfa-source-code
-    python /path/to/erfa-fetch/source_flattener.py src -n erfa
-
-If possible, however, it is recommended that you provide an option to use any
-copy of the ERFA library that is already installed on the system.
-
-.. _erfa-fetch repository: https://github.com/liberfa/erfa-fetch
-
 Cite As
 -------
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3564896.svg


### PR DESCRIPTION
The first commit removes the Travis build status section from the README. Travis has not been used since 5c9e64ec5034b2320b5c7bb1f4e4d841e20860c0, so there is no reason to mention it in the README at all.

The second commit removes references to the single-file version of ERFA that the `source_flattener.py` script from the `erfa-fetch` repository is supposed to produce. There are two separate issues opened on GitHub that report that the output of `source_flattener.py` does not compile, and nobody has shown any interest in fixing the script. The README should not advertise broken code. See also https://github.com/liberfa/erfa-fetch/pull/15