### PR TITLE
Update `configure.ac` with `autoupdate`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ([2.68])
 ## Follow the instructions in RELEASE.rst to change package version
 AC_INIT([erfa],[2.0.1])
 AC_CONFIG_SRCDIR([src/erfa.h])
-AC_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign])


### PR DESCRIPTION
`pyerfa` requires ERFA's `config.h` to be present. I tried to manually run the commands that the `pyerfa` `setup.py` file tries to run: https://github.com/liberfa/pyerfa/blob/88c25e6a125c4df2dadf0f969b8d626483722f62/setup.py#L126-L127
On current `master` I get
```
$ ./bootstrap.sh 
configure.ac:7: warning: The macro `AC_CONFIG_HEADER' is obsolete.
configure.ac:7: You should run autoupdate.
./lib/autoconf/status.m4:719: AC_CONFIG_HEADER is expanded from...
configure.ac:7: the top level
configure.ac:12: installing 'build-aux/compile'
configure.ac:10: installing 'build-aux/install-sh'
configure.ac:10: installing 'build-aux/missing'
src/Makefile.am:1: error: Libtool library used but 'LIBTOOL' is undefined
src/Makefile.am:1:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
src/Makefile.am:1:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
src/Makefile.am:1:   If 'LT_INIT' is in 'configure.ac', make sure
src/Makefile.am:1:   its definition is in aclocal's search path.
src/Makefile.am: installing 'build-aux/depcomp'
parallel-tests: installing 'build-aux/test-driver'
autoreconf: error: automake failed with exit status: 1
```
Following the instructions about running `autoupdate` produces 
```
$ autoupdate
$ git diff
diff --git a/configure.ac b/configure.ac
index a3dc59b..70bbda8 100644
--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.68])
+AC_PREREQ([2.71])
 ## Follow the instructions in RELEASE.rst to change package version
 AC_INIT([erfa],[2.0.1])
 AC_CONFIG_SRCDIR([src/erfa.h])
-AC_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign])
```
I did not see a need to update the requires version of `autoconf`, but I did check that [`AC_CONFIG_HEADERS` is present in `autoconf==2.68`](https://www.gnu.org/software/autoconf/manual/autoconf-2.68/html_node/Configuration-Headers.html).
With this patch I no longer get the warning, but I still get
```
$ ./bootstrap.sh 
configure.ac:12: installing 'build-aux/compile'
configure.ac:10: installing 'build-aux/install-sh'
configure.ac:10: installing 'build-aux/missing'
src/Makefile.am:1: error: Libtool library used but 'LIBTOOL' is undefined
src/Makefile.am:1:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
src/Makefile.am:1:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
src/Makefile.am:1:   If 'LT_INIT' is in 'configure.ac', make sure
src/Makefile.am:1:   its definition is in aclocal's search path.
src/Makefile.am: installing 'build-aux/depcomp'
parallel-tests: installing 'build-aux/test-driver'
autoreconf: error: automake failed with exit status: 1
$ aclocal
$ autoconf
$ ./bootstrap.sh 
src/Makefile.am:1: error: Libtool library used but 'LIBTOOL' is undefined
src/Makefile.am:1:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
src/Makefile.am:1:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
src/Makefile.am:1:   If 'LT_INIT' is in 'configure.ac', make sure
src/Makefile.am:1:   its definition is in aclocal's search path.
autoreconf: error: automake failed with exit status: 1
```
I don't know how to solve that.